### PR TITLE
0109 이화연 5문제

### DIFF
--- a/이화연/1주차/BOJ_11000_Gold5_강의실배정.java
+++ b/이화연/1주차/BOJ_11000_Gold5_강의실배정.java
@@ -1,0 +1,50 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_11000_강의실배정 {
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		Class[] c = new Class[N]; // 강의 담을 배열
+		for (int i = 0; i < N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int s = Integer.parseInt(st.nextToken());
+			int t = Integer.parseInt(st.nextToken());
+			c[i] = new Class(s, t);
+		}
+		Arrays.sort(c);
+
+		PriorityQueue<Integer> pq = new PriorityQueue<>();
+		pq.add(c[0].t); // 첫번째 강의의 종료 시간
+		for (int i = 1; i < N; i++) { // 첫번째 강의 이미 넣었으니 1부터 시작
+			if (pq.peek() <= c[i].s) { // 현재 큐에 들어가 있는 종료시간이 다음 강의 시작시간보다 작거나 같을경우
+				pq.poll();
+			}
+			pq.add(c[i].t);
+		}
+		System.out.println(pq.size());
+	}
+
+	static class Class implements Comparable<Class> {
+		int s, t;
+
+		public Class(int s, int t) {
+			super();
+			this.s = s;
+			this.t = t;
+		}
+
+		@Override
+		public int compareTo(Class o) {
+			if (this.s - o.s == 0) {
+				return this.t - o.t;
+			}
+			return this.s - o.s;
+		}
+	}
+}

--- a/이화연/1주차/BOJ_17503_Silver2_맥주축제.java
+++ b/이화연/1주차/BOJ_17503_Silver2_맥주축제.java
@@ -1,0 +1,64 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_17503_맥주축제 {
+	static int N, M, K;
+	static Beer[] beer;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+
+		beer = new Beer[K];
+		for (int i = 0; i < K; i++) {
+			st = new StringTokenizer(br.readLine());
+			int v = Integer.parseInt(st.nextToken());
+			int c = Integer.parseInt(st.nextToken());
+			beer[i] = new Beer(v, c);
+		}
+		Arrays.sort(beer);
+		PriorityQueue<Integer> pq = new PriorityQueue<>();
+		int sum = 0;
+		int ans = -1;
+		for (int i = 0; i < K; i++) {
+			pq.add(beer[i].v); // 선호도 더하기
+			sum += beer[i].v;
+			if (pq.size() > N) { // 사이즈 초과하면 가장 작은 선호도 뺌
+				sum -= pq.poll();
+			}
+
+			if (pq.size() == N && sum >= M) {
+				ans = beer[i].c;
+				break;
+			}
+
+		}
+		System.out.println(ans);
+	}
+
+	static class Beer implements Comparable<Beer> {
+		int v, c;
+
+		public Beer(int v, int c) {
+			super();
+			this.v = v;
+			this.c = c;
+		}
+
+		@Override
+		public int compareTo(Beer o) {
+			if (this.c == o.c) {
+				return o.v - this.v;
+			}
+			return this.c - o.c;
+		}
+	}
+
+}

--- a/이화연/1주차/BOJ_18126_Silver2_너구리구구.java
+++ b/이화연/1주차/BOJ_18126_Silver2_너구리구구.java
@@ -1,0 +1,52 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ_18126_너구리구구 {
+	static long answer = 0;
+	static int N;
+	static ArrayList<Edge>[] list;
+	static boolean[] visited;
+
+	static class Edge {
+		int to, c;
+
+		public Edge(int to, int c) {
+			this.to = to;
+			this.c = c;
+		}
+	}
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		list = new ArrayList[N + 1];
+		visited = new boolean[N + 1];
+		for (int i = 1; i <= N; i++) {
+			list[i] = new ArrayList<>();
+		}
+
+		for (int i = 1; i <= N - 1; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			int c = Integer.parseInt(st.nextToken());
+			list[a].add(new Edge(b, c));
+			list[b].add(new Edge(a, c));
+		}
+
+		visited[1] = true;
+		dfs(1, 0);
+		System.out.println(answer);
+	}
+
+	static void dfs(int n, long sum) {
+		answer = Math.max(sum, answer);
+
+		for (Edge next : list[n]) {
+			if (!visited[next.to]) {
+				visited[next.to] = true;
+				dfs(next.to, sum + next.c);
+			}
+		}
+	}
+}

--- a/이화연/1주차/BOJ_2583_Silver1_영역구하기.java
+++ b/이화연/1주차/BOJ_2583_Silver1_영역구하기.java
@@ -1,0 +1,88 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_2583_영역구하기 {
+	static int M, N, K;
+	static boolean[][] visited;
+	static int di[] = { -1, 1, 0, 0 };
+	static int dj[] = { 0, 0, -1, 1 };
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		M = Integer.parseInt(st.nextToken());
+		N = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		visited = new boolean[N][M];
+
+		for (int k = 0; k < K; k++) {
+			st = new StringTokenizer(br.readLine());
+			int x = Integer.parseInt(st.nextToken());
+			int y = Integer.parseInt(st.nextToken());
+			int x1 = Integer.parseInt(st.nextToken());
+			int y1 = Integer.parseInt(st.nextToken());
+			for (int i = x; i < x1; i++) {
+				for (int j = y; j < y1; j++) {
+					visited[i][j] = true; // 직사각형 그린 부분 방문 처리
+				}
+			}
+		}
+
+		int area = 0;
+		ArrayList<Integer> list = new ArrayList<Integer>();
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < M; j++) {
+				if (!visited[i][j]) { // 직사각형 없는 곳만
+					list.add(bfs(i, j));
+					area++;
+				}
+			}
+		}
+		System.out.println(area);
+		Collections.sort(list);
+		for (Integer i : list) {
+			System.out.print(i + " ");
+		}
+	}
+
+	static int bfs(int i, int j) {
+		Queue<Point> queue = new LinkedList<>();
+		queue.add(new Point(i, j));
+		visited[i][j] = true;
+
+		int count = 1; // 영역 넓이
+		while (!queue.isEmpty()) {
+			Point now = queue.poll();
+			for (int d = 0; d < 4; d++) {
+				int nexti = now.i + di[d];
+				int nextj = now.j + dj[d];
+
+				if (nexti < 0 || nexti >= N || nextj < 0 || nextj >= M || visited[nexti][nextj])
+					continue;
+
+				visited[nexti][nextj] = true;
+				queue.add(new Point(nexti, nextj));
+				count++;
+			}
+		}
+		return count;
+	}
+
+	static class Point {
+		int i, j;
+
+		public Point(int i, int j) {
+			super();
+			this.i = i;
+			this.j = j;
+		}
+	}
+
+}

--- a/이화연/1주차/PGM_12980_Level2_점프와순간이동.js
+++ b/이화연/1주차/PGM_12980_Level2_점프와순간이동.js
@@ -1,0 +1,14 @@
+function solution(n)
+{
+    let ans = 0;
+    while(n !== 0){
+        if(n % 2 === 1){ // 홀수일 경우에는 점프
+            n -= 1;
+            ans++;
+        }else{ // 짝수는 순간이동
+            n /= 2;
+        }
+    }
+
+    return ans;
+}


### PR DESCRIPTION
> ### [백준] 17503 맥주축제
> - 난이도 : `난이도`
> - 알고리즘 유형 : `우선순위 큐`
> - 내용
> ```
> 처음에 DFS로 접근해서 풀었는데 시간초과가 났음.. 우선순위 큐를 떠올리는 게 꽤나 쉽지 않았는데..  
> 우선순위 큐를 이용해서 큐 사이즈 N개 초과하면 가장 작은 선호도 빼고, 큐 사이즈 N이고 선호도 합계 M개 넘을때 break 해서 풀었슴다.
> ```

<br/>

> ### [백준] 18126 너구리구구
> - 난이도 : `실버2`
> - 알고리즘 유형 : `DFS`
> - 내용
> ```
> 그래프 만들어서 갈 수 있는 모든 방 방문하며 최장거리 구하는 문제라고 생각해서 DFS나 BFS 이용하면 되겠다고 생각함
> 입력조건 제대로 안보고 int로 선언해서 계속 틀린 문제..
> ```

<br/>

> ### [백준] 11000 강의실배정
> - 난이도 : `골드5`
> - 알고리즘 유형 : `우선순위큐`
> - 내용
> ```
> 입력값 Class 배열에 담고, 우선순위 큐에는 종료시간을 넣어서 현재 큐의 종료시간과 다음 강의 시작시간을 비교하면서 푸는 문제
> 비교 메소드 구현해놓고 정렬안해줘서 한번 틀렸던 ..
> ```

<br/>

> ### [백준] 2583 영역구하기
> - 난이도 : `실버1`
> - 알고리즘 유형 : `BFS/DFS`
> - 내용
> ```
> 분리된 각 영역의 넓이를 구하는 그래프 탐색 기본문제
> 직사각형 그린 부분은 방문 처리해준 다음 분리된 영역 넓이 구하기 위해서 방문하지 않은 곳만 BFS 탐색을 통해 구했다.
> ```

<br/>

> ### [프로그래머스] 12980 점프와 순간 이동
> - 난이도 : `Lv.2`
> - 알고리즘 유형 : `구현`
> - 내용
> ```
> 매 턴마다 점프/순간이동을 재귀로 돌리면 될듯해 DFS로 풀었는데 시간초과가 났다.
> 처음 위치에서 N을 만드는 것이 아니라 역으로 생각해 N을 0으로 만드는 식으로 해결함
> js연습할 겸 js로 풀었다 
> ```
