### PR TITLE
0116 조민규 5문제

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/algorithm.iml
+++ b/.idea/algorithm.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/algorithm.iml" filepath="$PROJECT_DIR$/.idea/algorithm.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/조민규/그리디/bj11047_동전0.java
+++ b/조민규/그리디/bj11047_동전0.java
@@ -1,0 +1,37 @@
+package 그리디;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class bj11047_동전0 {
+    public static int N, K; // N개의 줄, 동전가치 K
+    public static int[] A; // 동전의 가치
+    public static int cnt = 0; // 동전 개수
+    public static void main(String[] args) throws IOException {
+        // 입력
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        A = new int[N];
+        for(int i = 0 ; i < N ; i++){
+            A[i] = Integer.parseInt(br.readLine());
+        }
+
+        // 높은 가치의 동전부터 보자.
+        for(int i = A.length-1 ; i >= 0 ; i--){
+            // A[i]가 K보다 작을 때, K가 0이 되기 전까지 A[i]의 값을 반복해서 빼준다.
+            // K / A[i] (몫)으로 cnt를 표현할 수 있다.
+            // K % A[i] (나머지)으로 남은 K의 값을 표현할 수 있다.
+            if(K - A[i] >= 0){
+                cnt += K / A[i];
+                K = K % A[i];
+            }
+        }
+        
+        // 정답 출력
+        System.out.println(cnt);
+    }
+}

--- a/조민규/미분류/bj17503_맥주축제.java
+++ b/조민규/미분류/bj17503_맥주축제.java
@@ -1,0 +1,101 @@
+package 미분류;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class bj17503_맥주축제 {
+
+    static class Beer implements Comparable<Beer> {
+        public Long v, c; // 선호도, 도수 레벨
+
+        @Override
+        public Long compareTo(Beer o) {
+            return c - o.c;
+        }
+    }
+    static long N, M, K; // 축제 기간, 채워야 하는 선호도의 합, 맥주 종류 수
+    static PriorityQueue<Beer> beers; // 맥주들
+    static PriorityQueue<Beer> drinkBeers; // 마실 맥주들
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+
+        beers = new PriorityQueue<>(new Comparator<Beer>() {
+
+
+            @Override
+            public long compare(Beer o1, Beer o2) {
+                return o1.c - o2.c;
+            }
+        });
+        drinkBeers = new PriorityQueue<>(new Comparator<Beer>() {
+            @Override
+            public long compare(Beer o1, Beer o2) {
+                return o1.v - o2.v;
+            }
+        });
+
+        for(long i = 0 ; i < K ; i++){
+            st = new StringTokenizer(br.readLine());
+            Beer beer = new Beer();
+            beer.v = Long.parseLong(st.nextToken());
+            beer.c = Long.parseLong(st.nextToken());
+            beers.add(beer);
+        }
+
+        // 우선, 제일 앞의 N개의 맥주를 drinkBeers에 담는다.
+        long sumLike = 0;
+        long maxLevel = -1;
+        boolean flag = false; // true면 맥주 마실수있다!
+        for(long i = 0 ; i < N ; i++){
+            Beer tmp = beers.poll();
+            drinkBeers.add(tmp);
+            sumLike += tmp.v; // 선호도 누적 합
+            maxLevel = Math.max(maxLevel, tmp.c);
+        }
+
+        // 선호도를 다 채우지 못하면
+        if(sumLike < M){
+            // 선호도를 채울 수 있을때까지 반복한다.
+            for(long i = N ; i < K ; i++){
+
+                // drinkBeers에서 가장 낮은 선호도를 뺀다.
+                Beer outBeer = drinkBeers.poll();
+                Beer newBeer = beers.poll();
+
+                // sumLike에서 해당 beer의 도수를 뺀다.
+                sumLike -= outBeer.c;
+
+                // drinkBeers에 beers[i]를 넣는다.
+                drinkBeers.add(newBeer);
+
+                // sumLike에 beers[i]의 도수를 더한다.
+                sumLike += newBeer.c;
+
+                // 선호도를 채우면 탈출한다.
+                if(sumLike >= M){
+                    // 마실 수 있는 맥주 중 가장 높은 도수를 구한다.
+                    maxLevel = drinkBeers.poll().c;
+                    for(long j = 1 ; j < N ; j++){
+                        maxLevel = Math.max(maxLevel, drinkBeers.poll().c);
+                    }
+                    flag = true;
+                    break;
+                }
+            }
+        } else {
+            maxLevel = sumLike;
+        }
+
+        System.out.println(flag ? maxLevel : -1);
+    }
+}

--- a/조민규/미분류/bj18126_너구리구구.java
+++ b/조민규/미분류/bj18126_너구리구구.java
@@ -1,0 +1,65 @@
+package 미분류;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class bj18126_너구리구구 {
+
+    static class Edge {
+        int to, weight;
+
+        public Edge(int to, int weight) {
+            this.to = to;
+            this.weight = weight;
+        }
+    }
+
+    static int N;
+    static List<Edge>[] ways;
+    static boolean[] visited;
+    static long ans = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        ways = new ArrayList[N+1];
+        visited = new boolean[N+1];
+        for(int i = 1 ; i <= N ; i++){
+            ways[i] = new ArrayList<>();
+        }
+
+        for(int i = 1 ; i <= N-1 ; i++){
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            int weight = Integer.parseInt(st.nextToken());
+            ways[from].add(new Edge(to, weight));
+            ways[to].add(new Edge(from, weight));
+        }
+
+        dfs(1, 0);
+        System.out.println(ans);
+    }
+
+    public static void dfs(int now, long sumWeight){
+        // 방문처리
+        visited[now] = true;
+
+        // 지금까지 온 거리가 최장 거리일 경우
+        if(ans < sumWeight){
+            ans = sumWeight;
+        }
+
+        // 인접한 모든 edge들을 탐색한다.
+        for(Edge way : ways[now]){
+            if(visited[way.to]) continue;
+            dfs(way.to, sumWeight + way.weight);
+        }
+    }
+}

--- a/조민규/완전탐색/bj14501_퇴사.java
+++ b/조민규/완전탐색/bj14501_퇴사.java
@@ -1,0 +1,49 @@
+package 완전탐색;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class bj14501_퇴사 {
+    static int N; // N일만큼 남은 상담기간
+    static int[] T, P; // 상담 완료하는데 걸리는 기간, 받을 수 있는 금액
+    static int ans = 0; // 최대 수익
+    public static void main(String[] args) throws IOException {
+        // 입력
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        T = new int[N];
+        P = new int[N];
+        for(int i = 0 ; i < N ; i++){
+            st = new StringTokenizer(br.readLine());
+            T[i] = Integer.parseInt(st.nextToken());
+            P[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // 완전탐색
+        for(int i = 0 ; i < N ; i++){
+            sangdam(i, 0);
+        }
+        System.out.println(ans);
+    }
+
+    // now : 현재 상담날짜, money : 누적된 수익
+    public static void sangdam(int now, int money){
+        // 최종 수익 계산
+        if(now + T[now] >= N) {
+            money = now + T[now] == N ? money + P[now] : money; // 최종일에 딱 맞춰 끝나는 경우
+            ans = Math.max(ans, money);
+            return;
+        }
+        
+        // 상담
+        money += P[now];
+
+        // 다음 가능한 상담 날짜로 이동
+        for(int i = now+T[now] ; i < N ; i++){
+            sangdam(i, money);
+        }
+    }
+}

--- a/조민규/자료구조/bj2346_풍선터뜨리기.java
+++ b/조민규/자료구조/bj2346_풍선터뜨리기.java
@@ -1,0 +1,46 @@
+package 자료구조;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class bj2346_풍선터뜨리기 {
+    static int N; // 풍선의 개수
+    static int[] balloons; // 풍선에 써진 숫자들
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        balloons = new int[N];
+
+        st = new StringTokenizer(br.readLine());
+        for(int i = 0 ; i < N ; i++){
+            balloons[i] = Integer.parseInt(st.nextToken());
+        }
+
+        StringBuilder ans = new StringBuilder();
+        int curPosition = 0; // 현재 위치
+        for(int i = 0 ; i < N ; i++){
+            int tmp = balloons[curPosition];
+
+            // 현재 위치의 풍선을 터트림
+            balloons[curPosition] = 0; // 현재 풍선을 터트림
+            ans.append((curPosition+1) + " "); // 정답 문자열에 입력함
+            if(i == N-1) break;
+
+            // 풍선에 써 있는 숫자만큼 이동
+            for(int j = Math.abs(tmp); j > 0 ; j--){ // 풍선 이동 초깃값
+                if(tmp > 0){ // 값이 양수일 경우
+                    curPosition = (curPosition+1) % N; // +1만큼 위치 이동
+                }else { // 값이 음수일 경우
+                    curPosition = curPosition-1 < 0 ? N-1 : curPosition-1; // -1만큼 위치 이동
+                }
+
+                if(balloons[curPosition] == 0) ++j; // 이미 터진 풍선이면 한번 더 이동
+            }
+        }
+        System.out.println(ans);
+    }
+}


### PR DESCRIPTION
> ### [백준] 11047 동전0
> - 난이도 : `실버4`
> - 알고리즘 유형 : `그리디`
> - 내용
> ```
> 몇 개의 동전 단위를 주고 특정 값을 맞춰 구성하는 많이 보던 유형의 문제이다.
> 예를 들어 1000원을 맞춰야 하는 경우, 처음 K값 1000에서 빼가면서 0을 만들면 쉽다.
> A원을 반복문으로 빼줄까 했었는데, 남은 K값을 A원으로 나눠주면 몫이 A원의 갯수가 되고, 
> 나머지가 남은 K값이 된다.
> ```

<br/>

> ### [백준] 2346 풍선 터뜨리기
> - 난이도 : `실버3`
> - 알고리즘 유형 : `자료 구조`
> - 내용
> ```
> 원형 테이블에 앉은 사람들 있는 그 문제... 이름은 기억안나는데 암튼 그 문제랑 비슷했다!
> 터진 풍선은 건너뛰어야 하기에 내 머리로는 결국 반복문으로 한 칸씩 이동하는 것이 한계였다...
> 반복문 쓰지 않고 터진 풍선을 인지하면서 한번에 점프할 수 있는 방법이 없을까?
> ```

<br/>

> ### [백준] 14501 퇴사
> - 난이도 : `실버3`
> - 알고리즘 유형 : `완전탐색`
> - 내용
> ```
> 1일 ~ N일 중 어느 날에 상담 일정들을 잡아야 가장 수익이 좋을 지 계산하는 문제.
> 예를 들어 3일에 상담이 끝난다고 4일에 바로 상담을 시작하는것보다 
> 이틀 쉬고 6일에 다음 상담을 하는게 더 그리디할 수 있으므로
> 모든 경우를 일일이 다 보는 완전탐색으로 풀어야 한다.
> ```

<br/>

> ### [백준] 17503 맥주축제
> - 난이도 : `실버2`
> - 알고리즘 유형 : `우선순위 큐`
> - 내용
> ```
> 아시다시피 패기롭게 배열로 입력값 받고 완전탐색하면 시간초과 나는 문제.
> 우선순위 큐로 입력받은 맥주값 beers, 마실 맥주들을 저장하는 drinkBeers를 만들었다.
> beers는 도수 레벨 오름차순으로, drinkBeers는 낮은 선호도의 맥주들을 나중에 빼줘야 하기에 선호도 오름차순으로 정렬했다.
> 근데 나중에 봤는데 long 써야 문제 풀릴거같은데
> long 정렬은 어케하죠
> 원인은 알거같은데 아직 해결은 못한문제....
> ```

<br/>

> ### [백준]  18126 너구리 구구
> - 난이도 : `실버2`
> - 알고리즘 유형 : `dfs`
> - 내용
> ```
> 기본적인 그래프 및 dfs 문제인 줄 알고 호기롭게 제출했더니 틀렸다고 떴다.
> 이럴리가 없는데 뭐가 문제지 하고 고민하다가 머릿속을 스쳐지나가는 long이 떠올랐다.
> 문제 조건에서도 C의 값이 최대 1,000,000,000까지였고, long으로 바꾸니 문제가 해결되었다.
> 문제 조건 잘 읽기, 많이 풀어서 짬바 높이기...
> ```
