### PR TITLE
0116 육다빈 5문제

### DIFF
--- a/육다빈/week2_0117/백준_11426.java
+++ b/육다빈/week2_0117/백준_11426.java
@@ -1,0 +1,51 @@
+package silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class S11426_findPrefix {
+
+	static boolean isPrefix(String s, char[] now) {
+		int size = now.length;
+		for(int j=0; j<size; j++) {
+			if(s.charAt(j)!=now[j]) return false;
+		}
+		return true;
+	}
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		List<String>[] str = new List[26];
+		for(int i=0; i<26; i++) str[i] = new ArrayList<String>();
+		
+		for(int i=0; i<N; i++) {
+			String s = br.readLine();
+			str[s.charAt(0)-'a'].add(s);
+		}
+		
+		int cnt = 0;
+		for(int i=0; i<M; i++) {
+			char[] now = br.readLine().toCharArray();
+			int idx = now[0]-'a';
+			for(String s : str[idx]) {
+				if(isPrefix(s, now)) {
+					cnt++;
+					break;
+				}
+			}
+		}
+		
+		System.out.println(cnt);
+		
+	}
+
+}

--- a/육다빈/week2_0117/백준_14620.java
+++ b/육다빈/week2_0117/백준_14620.java
@@ -1,0 +1,69 @@
+package silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class S14620_flowerRoad {
+	static int N;
+	static int[] di = {-1, 0, 1, 0};
+	static int[] dj = {0, 1, 0, -1};
+	static int[][] map;
+	static int[][] cost;
+	static int[][] visit;
+	
+	static int calcCost(int i, int j) { 
+		int sum = map[i][j];
+		for(int d=0; d<4; d++) sum += map[i+di[d]][j+dj[d]];
+		return sum;
+	}
+	
+	static boolean isOkay(int ni, int nj) {
+		for(int i=0; i<2; i++) {
+				if(Math.abs(ni-visit[i][0]) + Math.abs(nj-visit[i][1]) <= 2) return false;
+		}
+		return true;
+	}
+	
+	static int comb(int n, int cnt, int sum) {
+		System.out.print(n + " -> ");
+		if(cnt==3) {
+			System.out.println(" ////");
+			return sum;
+		}
+		int max = 0;
+		for(int k=n; k<N*N; k++) {
+			int ni = k / N;
+			int nj = k % N;
+			if(ni==0 || ni==N-1 || nj==0 || nj==N-1 || isOkay(ni, nj)) continue;
+			visit[cnt][0] = ni;
+			visit[cnt][1] = nj;
+			max = Math.max(max, comb(k+1, cnt+1, sum+cost[ni][nj]));
+		}
+		return max;
+	}
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		map = new int[N][N];
+		cost = new int[N][N];
+		visit = new int[3][2];
+		
+		for(int i=0; i<N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for(int j=0; j<N; j++) map[i][j] = Integer.parseInt(st.nextToken());
+		}
+		
+		for(int i=1; i<N-1; i++) {
+			for(int j=1; j<N-1; j++) cost[i][j] = calcCost(i, j);
+			System.out.println(Arrays.toString(cost[i]));
+		}
+		
+		
+		System.out.println(comb(0, 0, 0));
+	}
+
+}

--- a/육다빈/week2_0117/백준_14620.java
+++ b/육다빈/week2_0117/백준_14620.java
@@ -3,46 +3,43 @@ package silver;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.Arrays;
 import java.util.StringTokenizer;
 
 public class S14620_flowerRoad {
 	static int N;
 	static int[] di = {-1, 0, 1, 0};
 	static int[] dj = {0, 1, 0, -1};
-	static int[][] map;
-	static int[][] cost;
-	static int[][] visit;
+	static int[][] map; // 칸당 부과되는 비용
+	static int[][] cost; // 해당 칸을 중심으로 꽃 생성 시 발생 비용
+	static int[][] visit; // 이전에 선택한 꽃의 중심칸
 	
-	static int calcCost(int i, int j) { 
+	static int calcCost(int i, int j) { // (i, j)칸이 중심인 꽃의 비용
 		int sum = map[i][j];
 		for(int d=0; d<4; d++) sum += map[i+di[d]][j+dj[d]];
 		return sum;
 	}
 	
-	static boolean isOkay(int ni, int nj) {
-		for(int i=0; i<2; i++) {
+	static boolean isOkay(int ni, int nj, int cnt) { // 이전에 선택한 꽃들과 겹쳐지는지 확인
+		for(int i=0; i<cnt; i++) {
 				if(Math.abs(ni-visit[i][0]) + Math.abs(nj-visit[i][1]) <= 2) return false;
 		}
 		return true;
 	}
 	
-	static int comb(int n, int cnt, int sum) {
-		System.out.print(n + " -> ");
-		if(cnt==3) {
-			System.out.println(" ////");
-			return sum;
-		}
-		int max = 0;
+	static int comb(int n, int cnt, int sum) { // 전체 칸 중 3개 선택하여 합한 값 중 최소값 반환
+		if(cnt==3) return sum;
+
+		int min = Integer.MAX_VALUE;
 		for(int k=n; k<N*N; k++) {
 			int ni = k / N;
 			int nj = k % N;
-			if(ni==0 || ni==N-1 || nj==0 || nj==N-1 || isOkay(ni, nj)) continue;
+			if(ni==0 || ni==N-1 || nj==0 || nj==N-1 || !isOkay(ni, nj, cnt)) continue;
+			
 			visit[cnt][0] = ni;
 			visit[cnt][1] = nj;
-			max = Math.max(max, comb(k+1, cnt+1, sum+cost[ni][nj]));
+			min = Math.min(min, comb(k+1, cnt+1, sum+cost[ni][nj]));
 		}
-		return max;
+		return min;
 	}
 	
 	public static void main(String[] args) throws IOException{
@@ -59,7 +56,6 @@ public class S14620_flowerRoad {
 		
 		for(int i=1; i<N-1; i++) {
 			for(int j=1; j<N-1; j++) cost[i][j] = calcCost(i, j);
-			System.out.println(Arrays.toString(cost[i]));
 		}
 		
 		

--- a/육다빈/week2_0117/백준_1931.java
+++ b/육다빈/week2_0117/백준_1931.java
@@ -1,0 +1,46 @@
+package silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class S1931_meetingRoom {
+
+	static class Room implements Comparable<Room>{
+		long start, end;
+		Room(long start, long end){
+			this.start = start;
+			this.end = end;
+		}
+		@Override
+		public int compareTo(Room o) {
+			if(this.end == o.end) return (int) (this.start-o.start);
+			return (int) (this.end - o.end);
+		}
+	}
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		
+		PriorityQueue<Room> rooms = new PriorityQueue<Room>();
+		for(int i=0; i<N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			rooms.add(new Room(Long.parseLong(st.nextToken()), Long.parseLong(st.nextToken())));
+		}
+		
+		long now = 0, result = 0;
+		while(!rooms.isEmpty()) {
+			Room r = rooms.poll();
+			if(now <= r.start) {
+				now = r.end;
+				result++;
+			}
+		}
+		
+		System.out.println(result);
+	}
+
+}

--- a/육다빈/week2_0117/백준_20413.java
+++ b/육다빈/week2_0117/백준_20413.java
@@ -1,0 +1,52 @@
+package silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class S20413_MVPDiamond {
+	
+	static int gradeToIdx(char c) { // 등급 기준액이 저장된 배열(limit)의 인덱스를 반환
+		switch(c) {
+			case 'B' : return 0;
+			case 'S' : return 1;
+			case 'G' : return 2;
+			case 'P' : return 3;
+			case 'D' : return 4;
+			default : return -1;
+		}
+	}
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int[] limit = new int[5]; // 등급 기준액
+		for(int i=1; i<5; i++) limit[i] = Integer.parseInt(st.nextToken()); 
+		
+		char[] grade = br.readLine().toCharArray(); // 배정받은 등급
+		Queue<Integer> money = new LinkedList<Integer>(); // 과금액
+		int sum = 0; // 2개월간 과금액 합계
+		int result = 0; // 총 과금액
+		
+		for(int i=0; i<N; i++) {
+			int idx = gradeToIdx(grade[i])+1; 
+			int max = (idx > 4) ? -1 : limit[idx]; // 배정받은 등급 최대 누적 과금액 (최고등급은 -1)
+			
+			int tmp = max-1-sum; //이번달 과금액
+			if(tmp > limit[4] || tmp < 0) tmp = limit[4];
+
+			money.add(tmp);
+			result += tmp;
+			
+			if(money.size()<2) sum += tmp; 
+			else sum += tmp - money.poll();
+		}
+		System.out.println(result);
+	}
+
+}

--- a/육다빈/week2_0117/백준_2468.java
+++ b/육다빈/week2_0117/백준_2468.java
@@ -1,0 +1,87 @@
+package silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class S2468_safeZone {
+	static int N;
+	static int[][] map;
+	static boolean[][] visit;
+	static int di[] = {-1, 0, 1, 0};
+	static int dj[] = {0, 1, 0, -1};
+	
+	static class Point{
+		int i, j;
+		Point(int i, int j){
+			this.i = i;
+			this.j = j;
+		}
+	}
+	
+	static void bfs(int i, int j, int h) {
+		Queue<Point> queue = new LinkedList<Point>();
+		queue.add(new Point(i, j));
+		visit[i][j] = true;
+		
+		while(!queue.isEmpty()) {
+			int size = queue.size();
+			
+			for(int s=0; s<size; s++) {
+				Point p = queue.poll();
+				
+				for(int d=0; d<4; d++) {
+					int ni = p.i + di[d];
+					int nj = p.j + dj[d];
+					
+					if(ni<0 || ni>=N || nj<0 || nj>=N || map[ni][nj]<=h || visit[ni][nj]) continue;
+					queue.add(new Point(ni, nj));
+					visit[ni][nj] = true;
+				}
+			}
+		}
+	}
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		N = Integer.parseInt(br.readLine());
+		map = new int[N][N];
+		Queue<Point> queue = new LinkedList<>();
+		
+		for(int i=0; i<N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for(int j=0; j<N; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+				queue.add(new Point(i, j));
+			}
+		}
+		
+		int result = 1;
+		for(int h=1; h<=100; h++) {
+			visit = new boolean[N][N];
+			int size = queue.size();
+			int cnt = 0;
+			
+			for(int j=0; j<size; j++) {
+				Point now = queue.poll(); 
+			
+				if(map[now.i][now.j]>h) {
+					queue.add(now); //현재 높이보다 높으니 다음 높이에서 탐색 대상이 됨
+					
+					if(!visit[now.i][now.j]) { // 이번 높이에서 방문한 적 없으면 너비탐색
+						bfs(now.i, now.j, h);
+						cnt++;
+					}
+				}
+			}
+			result = Math.max(result, cnt);
+			if(queue.isEmpty()) break;
+		}
+		
+		System.out.println(result);
+	}
+
+}


### PR DESCRIPTION
> ### [백준] 11426 접두사 찾기
> - 난이도 : `실버 2`
> - 알고리즘 유형 : `자료구조`, `문자열`
> - 내용
> ```
> 집합 안에 있는 문자열들을 시작 알파벳별로 분류하여 배열에 저장하고, 이후 입력받은 문자열들에 대하여 
> 첫글자가 같은 문자열들만 앞글자부터 모두 확인해보도록 했습니다.
> ```

<br/>

> ### [백준] 20413 MVP 다이아몬드 (Easy)
> - 난이도 : `실버 2`
> - 알고리즘 유형 : `그리디`
> - 내용
> ```
> 등급이 떨어질 일이 없으므로, 직전 과금액 + 현재 과금액 = 배정받은 등급의 다음등급 기준액 - 1이 되도록 
> 매 월 과금액을 계산하면 됩니다. 뭔가 로직적인 문제보다, 과금액을 저장할 자료구조를 어떻게 하면 깔끔할지
> 고민을 많이 했던.. 문제
> ```

<br/>

> ### [백준] 2468 안전 영역
> - 난이도 : `실버 1`
> - 알고리즘 유형 : `브루트포스` `BFS`
> - 내용
> ```
> 높이를 0부터 시작해서, 현재 높이보다 높은 칸들만 담긴 큐에서 하나씩 뽑아서 너비우선탐색을 해주었습니다.
> 기존의 방문체크만 하던 BFS방식에서 한번 더 꼬아서, 높이까지 고려해야 했던 문제.
> ```

<br/>

> ### [백준] 1931 회의실 배정
> - 난이도 : `실버 1`
> - 알고리즘 유형 : `그리디`, `우선순위 큐`
> - 내용
> ```
> 회의 종료시간 오름차순으로 회의실 정보를 입력받아 우선순위 큐에 넣어서 풀었습니다.
> 앞에서부터 하나씩 빼서 현재 시간보다 시작시간이 이후인 경우만 회의실 배정을 해주면 됩니다.
>
> 계속 틀렸던 이유는, (4, 4) (4, 4) (1, 4) 이런식으로 3개가 들어오면 3개 모두를 배정해야 하는데 
> 종료시간이 동일 할 경우 시작시간 순으로 내림차순 정리 하지 않아 마지막 회의(1, 4)가 배정되지 않더라구요...
> ```

<br/>

> ### [백준] 14620 꽃길
> - 난이도 : `실버 2`
> - 알고리즘 유형 : `브루트포스`, `조합`
> - 내용
> ```
> 가운데를 중심으로 사방을 차지하는 꽃 3개를 겹쳐지지 않게 만드는 최소 비용을 구하는 문제.
> 얼핏 보면 DFS인듯 보였던 문제였지만, 전체 칸에 대하여 사방탐색으로 꽃을 만드는데 필요한 비용을 계산하고
> 조합으로 최소가 되는 선택을 찾으면 되는 문제였습니다.
> ```
