### PR TITLE
0206 이화연 5문제

### DIFF
--- a/이화연/4주차/BOJ_Silver1_11057_오르막수.java
+++ b/이화연/4주차/BOJ_Silver1_11057_오르막수.java
@@ -1,0 +1,31 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_Silver1_11057_오르막수 {
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine()); // 수의 길이
+		int[][] dp = new int[N + 1][10];
+		int[] result = new int[N + 1]; // N길이의 오르막 수 개수 총합을 담을 배열
+
+		for (int i = 0; i < 10; i++) {
+			dp[1][i] = 1; // 수의 길이가 1일 경우에는 모두 경우의 수가 1임
+			result[1] += dp[1][i];
+		}
+
+		// n : 수의 길이, j : 끝의 자리 수
+		for (int n = 2; n <= N; n++) {
+			dp[n][0] = 1;
+			result[n] += dp[n][0];
+			for (int j = 1; j < 10; j++) {
+				dp[n][j] = (dp[n][j - 1] + dp[n - 1][j]) % 10007;
+				result[n] += dp[n][j]; // 계산할때마다 n길이의 오르막 수 개수 더해주기
+			}
+		}
+
+		System.out.println(result[N] % 10007);
+	}
+
+}

--- a/이화연/5주차/BOJ_9655_돌게임.java
+++ b/이화연/5주차/BOJ_9655_돌게임.java
@@ -1,0 +1,13 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_9655_돌게임 {
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		System.out.println(N % 2 == 0 ? "CY" : "SK");
+	}
+
+}

--- a/이화연/5주차/BOJ_Gold5_14921_용액합성하기.java
+++ b/이화연/5주차/BOJ_Gold5_14921_용액합성하기.java
@@ -1,0 +1,37 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_Gold5_14921_용액합성하기 {
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+
+		int[] A = new int[N];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++) {
+			A[i] = Integer.parseInt(st.nextToken());
+		}
+
+		int start = 0;
+		int end = N - 1;
+		int min = 100000000; //두 용액의 합의 절댓값
+		int ans = 0; //두 용액 섞은 합
+		while (start != end) {
+			int sum = A[start] + A[end];
+			if (sum < 0) { //만약 음수가 나올경우 start + 1
+				start++;
+			} else { // 양수일경우 end -1
+				end--;
+			}
+			if (min > Math.abs(sum)) { //합의 절댓값이 min보다 작을때, min과 ans 갱신
+				min = Math.abs(sum);
+				ans = sum;
+			}
+		}
+		System.out.println(ans);
+	}
+
+}

--- a/이화연/5주차/BOJ_Gold5_1662_압축.java
+++ b/이화연/5주차/BOJ_Gold5_1662_압축.java
@@ -1,0 +1,42 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ_Gold5_1662_압축 {
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		String S = br.readLine();
+
+		Stack<Integer> stack = new Stack<Integer>(); // 길이를 저장할 스택
+		for (int i = 0; i < S.length(); i++) {
+			String now = S.charAt(i) + "";
+			if (now.equals("(")) { // 여는괄호는 -1로 넣어주자
+				stack.push(-1);
+			} else if (now.equals(")")) {
+				// 닫는괄호를 만났으니 여는괄호를 찾아보자
+				int index = 0; // 여는괄호 만나기 전까지 길이
+				while (true) {
+					int before = stack.pop();
+					if (before != -1) { // 여는괄호 아닐경우 길이 증가
+						index += before;
+					} else {
+						break;
+					}
+				}
+				int k = stack.pop(); // 반복할 숫자 k
+				stack.push(k * index); // k랑 여는괄호 만나기 전까지 길이 곱해서 스택에 넣기
+			} else if (i < S.length() - 1 && S.charAt(i + 1) == '(') { // 숫자 + (
+				stack.push(Integer.parseInt(now)); // 다음이 여는 괄호면 K번 반복이니 그 숫자 그대로 넣어줌
+			} else { // 숫자 + 숫자
+				stack.push(1);
+			}
+
+		}
+
+		int ans = 0;
+		while (!stack.isEmpty()) {
+			ans += stack.pop(); // 길이 더하기
+		}
+		System.out.println(ans);
+	}
+}

--- a/이화연/5주차/BOJ_Gold5_수이어쓰기2.java
+++ b/이화연/5주차/BOJ_Gold5_수이어쓰기2.java
@@ -1,0 +1,44 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_Gold5_수이어쓰기2 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken()); // N까지 수 이어 쓰기
+		int k = Integer.parseInt(st.nextToken()); // k번째 자리 숫자
+
+		// k번째 자리의 숫자가 포함되는 실제 숫자의 길이를 구한다.
+		int length = 1;
+		while (true) {
+			long sum = (long) (length * Math.pow(10, length - 1) * 9);
+			if (sum < k) { // k가 length 자리 수 총 개수보다 클 경우
+				length++; // 자리 수 증가
+				k -= sum; // 해당하는 자리 수가 아니니까 빼줘야함
+			} else {
+				break;
+			}
+		}
+//		System.out.println(length + " " + index);
+
+		int realNum = (int) (Math.pow(10, length - 1) + (k / length)) - 1; // k번째 자리의 숫자가 포함되는 실제 숫자 구하기
+		int remain = k % length; // k번째 자리 수를 length길이로 나눈 나머지
+		String strRealNum = String.valueOf(realNum);
+
+		if (N < realNum) { // k번째 숫자를 포함한 실제 숫자가 N보다 작으면
+			System.out.println(-1);
+			return;
+		}
+
+		if (remain == 0) { // 나머지가 0이면 마지막 숫자 출력
+			System.out.println(strRealNum.charAt(strRealNum.length() - 1));
+		} else {
+			System.out.println(strRealNum.substring(remain - 1, remain));
+		}
+
+	}
+
+}

--- a/이화연/5주차/BOJ_Silver3_1003_피보나치함수.java
+++ b/이화연/5주차/BOJ_Silver3_1003_피보나치함수.java
@@ -1,0 +1,33 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_Silver3_1003_피보나치함수 {
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		int[][] dp = new int[41][2];
+		dp[0][0] = 1;
+		dp[0][1] = 0;
+		dp[1][0] = 0;
+		dp[1][1] = 1;
+
+		for (int t = 0; t < T; t++) {
+			int N = Integer.parseInt(br.readLine());
+
+			if (N < 2) {
+				System.out.println(dp[N][0] + " " + dp[N][1]);
+				continue;
+			}
+
+			for (int i = 2; i <= N; i++) {
+				if (dp[i][0] == 0 && dp[i][1] == 0) {
+					dp[i][0] = dp[i - 1][0] + dp[i - 2][0];
+					dp[i][1] = dp[i - 1][1] + dp[i - 2][1];
+				}
+			}
+			System.out.println(dp[N][0] + " " + dp[N][1]);
+		}
+	}
+}


### PR DESCRIPTION
> ### [백준] 1662 압축
> - 난이도 : `골드5`
> - 알고리즘 유형 : `문자열`
> - 내용
> ```
> 문자열 문제라서 스택을 이용해서 풀어야겠다고 했고 처음에 풀때는 뒤에서부터 인덱스계산하면서 풀었는데 모든 테케에 맞지 않는 오답이었음
> 올바른 해결 방법
> 1. `(` 일경우에는 stack을 Integer로 만들었기때문에 `-1` push
> 2. `숫자 + (` 일경우에는 숫자가 k번 반복해야하는 숫자이므로 그대로 push
> 3. `숫자 + 숫자` 일경우에는 길이는 1이니 `1` push
> 4. `)` 일경우에는 `(` 를 찾자
>    1) `-1 = (` 만나기 전까지 `index`에 현재 꺼낸 값 더해주기
>    2) `-1` 만났을 때 stack에서 `k`를 꺼내서 `index`와 곱한 값을 다시 stack에 넣는다
> ⇒ 스택 돌면서 더해주면 압축 전 문자열 길이
> ```

<br/>

> ### [백준] 1790 수이어쓰기2 (F)
> - 난이도 : `골드5`
> - 알고리즘 유형 : `문자열`
> - 내용
> ```
> 1. k번째 자리 숫자가 포함되는 실제 숫자의 길이를 구하기
>    - 현재 숫자 길이의 인덱스 총 합을 구해서 k보다 작으면 자리수 증가, k에서 합 빼주면서 반복
> 2. 실제 숫자는 자리수에서 인덱스/자리수를 더하고 -1을 한 값
> 3. 만약 실제 숫자가 N보다 클 경우 k번째 수를 구할 수 없음
>    - 아닐 경우 나머지가 0이면 맨 뒷자리 출력, 나머지가 있으면 나머지-1자리 출력
> 3%에서 틀렸다고 나온다..........어떤 반례가 있는걸까
> ```

<br/>

> ### [백준] 14921 용액합성하기
> - 난이도 : `골드5`
> - 알고리즘 유형 : `투포인터`
> - 내용
> ```
> 문제를 보니 두 용액을 혼합해서 0에 가까운 용액을 구해야 하고, 용액들이 오름차순으로 정렬되어 있길래 바로 투포인터를 이용해서 풀면 되겠다고 생각했다
> ```

<br/>

> ### [백준] 9655 돌게임
> - 난이도 : `실버5`
> - 알고리즘 유형 : DP`
> - 내용
> ```
> DP 문제였지만,, N이 1부터 5까지 계산을 해봤더니 무조건 짝수일경우에는 상근이가 이기고 홀수일경우에는 창영이가 이기는 규칙을 갖고 있어서 그대로 출력했더니 정답..!
> ```

<br/>

> ### [백준] 1003 피보나치함수
> - 난이도 : `실버3`
> - 알고리즘 유형 : `DP`
> - 내용
> ```
> 2차원 배열을 만들어 `dp[i][0]`은 0의 출력 횟수 `dp[i][1]`은 1 출력 횟수로 생각해 계산해 줌
> 테케 실행 중 이미 갱신된 `dp[i][]`의 값을 또 계산하는 일이 없게 `dp[i][0] == 0 && dp[i][1] == 0` 일때만 계산을 해주도록 함
> ```
