### PR TITLE
0213 이화연 5문제

### DIFF
--- a/이화연/5주차/BOJ_Gold5_1790_수이어쓰기2.java
+++ b/이화연/5주차/BOJ_Gold5_1790_수이어쓰기2.java
@@ -3,7 +3,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.StringTokenizer;
 
-public class BOJ_Gold5_수이어쓰기2 {
+public class BOJ_Gold5_1790_수이어쓰기2 {
 
 	public static void main(String[] args) throws IOException {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
@@ -11,32 +11,36 @@ public class BOJ_Gold5_수이어쓰기2 {
 		int N = Integer.parseInt(st.nextToken()); // N까지 수 이어 쓰기
 		int k = Integer.parseInt(st.nextToken()); // k번째 자리 숫자
 
-		// k번째 자리의 숫자가 포함되는 실제 숫자의 길이를 구한다.
-		int length = 1;
+		int length = 1; // 자릿수
+		int realNum = 0; // k가 포함된 실제숫자
 		while (true) {
-			long sum = (long) (length * Math.pow(10, length - 1) * 9);
-			if (sum < k) { // k가 length 자리 수 총 개수보다 클 경우
-				length++; // 자리 수 증가
-				k -= sum; // 해당하는 자리 수가 아니니까 빼줘야함
-			} else {
+			int cnt = (int) (length * Math.pow(10, length - 1) * 9);
+			if (k - cnt < 0) {
 				break;
 			}
+			realNum += Math.pow(10, length - 1) * 9; // 현재길이의 가장 끝자리수를 만들기
+			k -= cnt; // 해당하는 자리 수가 아니니까 빼줘야함
+			length++; // 자리 수 증가
 		}
-//		System.out.println(length + " " + index);
 
-		int realNum = (int) (Math.pow(10, length - 1) + (k / length)) - 1; // k번째 자리의 숫자가 포함되는 실제 숫자 구하기
-		int remain = k % length; // k번째 자리 수를 length길이로 나눈 나머지
-		String strRealNum = String.valueOf(realNum);
+		int remain = k % length;
+
+		if (remain == 0) {
+			realNum += k / length;
+		} else {
+			realNum += k / length + 1; // 나머지가 있는건 현재수의 그 다음수에 k가 있다는 것
+		}
 
 		if (N < realNum) { // k번째 숫자를 포함한 실제 숫자가 N보다 작으면
 			System.out.println(-1);
 			return;
 		}
 
+		String strRealNum = String.valueOf(realNum);
 		if (remain == 0) { // 나머지가 0이면 마지막 숫자 출력
 			System.out.println(strRealNum.charAt(strRealNum.length() - 1));
 		} else {
-			System.out.println(strRealNum.substring(remain - 1, remain));
+			System.out.println(strRealNum.charAt(remain - 1));
 		}
 
 	}

--- a/이화연/6주차/BOJ_Gold5_13023_ABCDE.java
+++ b/이화연/6주차/BOJ_Gold5_13023_ABCDE.java
@@ -1,0 +1,57 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class BOJ_Gold5_13023_ABCDE {
+	static int N, M, max = 0;
+	static ArrayList<Integer>[] list;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+
+		list = new ArrayList[N];
+		for (int i = 0; i < N; i++) {
+			list[i] = new ArrayList<Integer>();
+		}
+
+		for (int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			list[a].add(b);
+			list[b].add(a);
+		}
+
+		// 모든 정점을 돌면서 A-B-C-D-E인 경우를 찾는다
+		for (int i = 0; i < N; i++) {
+			boolean[] visited = new boolean[N];
+			dfs(i, 0, visited);
+			if (max >= 4) {
+				System.out.println(1);
+				return;
+			}
+		}
+		System.out.println(0);
+	}
+
+	static void dfs(int num, int depth, boolean[] v) {
+		if (depth > 3) { // A-B-C-D-E인 경우
+			max = Math.max(max, depth);
+			return;
+		}
+
+		for (Integer i : list[num]) {
+			if (!v[i]) {
+				v[num] = true;
+				dfs(i, depth + 1, v);
+				v[num] = false; // 만약 현재 리스트에 정점이 한개 이상이라면 다른 경로도 탐색해야하기 때문에
+			}
+		}
+	}
+
+}

--- a/이화연/6주차/BOJ_Gold5_2138_전구와스위치.java
+++ b/이화연/6주차/BOJ_Gold5_2138_전구와스위치.java
@@ -1,0 +1,56 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class BOJ_Gold5_2138_전구와스위치 {
+	static int N, min;
+	static char[] nowStatus, makeStatus;
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		nowStatus = br.readLine().toCharArray();
+		makeStatus = br.readLine().toCharArray();
+		min = Integer.MAX_VALUE;
+
+		// 0번 스위치 안 눌렀을 때
+		char[] newArray = Arrays.copyOf(nowStatus, N);
+		pressCount(newArray, 0);
+
+		// 0번 스위치 눌렀을 때 : 0,1번 스위치 반전
+		char[] newArray2 = Arrays.copyOf(nowStatus, N);
+		newArray2[0] = switchStatus(nowStatus, 0);
+		newArray2[1] = switchStatus(nowStatus, 1);
+		pressCount(newArray2, 1);
+
+		System.out.println(min == Integer.MAX_VALUE ? -1 : min);
+
+	}
+
+	// 스위치 누르는 횟수 세기
+	static void pressCount(char[] str, int cnt) {
+		for (int i = 1; i < N; i++) {
+			if (str[i - 1] != makeStatus[i - 1]) { // 전 인덱스의 값이 다를 경우 스위치 누르기
+				cnt++; // 스위치 횟수 증가
+				if (i - 1 >= 0) // i-1
+					str[i - 1] = switchStatus(str, i - 1);
+				str[i] = switchStatus(str, i); // i
+				if (i + 1 < N) // i+1
+					str[i + 1] = switchStatus(str, i + 1);
+			}
+		}
+		if (String.valueOf(str).equals(String.valueOf(makeStatus))) { // 만들고자 하는 상태와 같을 경우
+			min = Math.min(min, cnt);
+		}
+	}
+
+	// 전구 상태 반전시키기
+	static char switchStatus(char[] str, int index) {
+		if (str[index] == '0') {
+			return '1';
+		}
+		return '0';
+	}
+
+}

--- a/이화연/6주차/BOJ_Gold5_7490_0만들기.java
+++ b/이화연/6주차/BOJ_Gold5_7490_0만들기.java
@@ -1,0 +1,49 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_Gold5_7490_0만들기 {
+	static int N;
+	static StringBuilder sb;
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		sb = new StringBuilder();
+
+		for (int t = 0; t < T; t++) {
+			N = Integer.parseInt(br.readLine());
+			dfs(2, 1, 1, -2, String.valueOf(1));
+			sb.append("\n");
+		}
+		System.out.println(sb.toString());
+	}
+
+	// num : 현재 수, sum : 현재까지 더한값, before : 바로 전 수, sign : 바로 전에 삽입한 부호
+	// sign은 -1(-), 1(+), 0(공백)
+	static void dfs(int num, int sum, int before, int sign, String s) {
+		if (num == N + 1) { // 마지막 수까지 다 고려했을 경우
+			if (sum == 0) {
+				sb.append(s + "\n");
+			}
+			return;
+		}
+
+		String str = String.valueOf(num);
+		// 공백을 삽입할 경우
+		int newNum = Integer.parseInt(String.valueOf(before) + str); // 바로 전수와 현재수를 이어붙인다
+		int newSum = sum; // 새로운 sum값
+		if (sign == 1) { // 바로 전에 삽입한 부호가 +일경우 전 수를 빼준다음 newNum을 더해줌
+			newSum = sum - before + newNum;
+		} else if (sign == -1) { // 바로 전에 삽입한 부호가 -일경우 전 수를 더해준다음 newNum 빼줌
+			newSum = sum + before - newNum;
+		} else { // 바로 전에 공백을 삽입했을 경우 newSum을 newNum으로 갱신
+			newSum = newNum;
+		}
+		// ASCII 순서는 공백 -> + -> - 임
+		dfs(num + 1, newSum, newNum, 0, s + " " + str); // 공백
+		dfs(num + 1, sum + num, num, 1, s + "+" + str); // +
+		dfs(num + 1, sum - num, num, -1, s + "-" + str); // -
+	}
+
+}

--- a/이화연/6주차/BOJ_Silver1_15900_나무탈출.java
+++ b/이화연/6주차/BOJ_Silver1_15900_나무탈출.java
@@ -1,0 +1,48 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class BOJ_Silver1_15900_나무탈출 {
+	static ArrayList[] tree;
+	static boolean[] visited;
+	static int ans;
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+
+		tree = new ArrayList[N + 1];
+		visited = new boolean[N + 1];
+		for (int i = 1; i <= N; i++) {
+			tree[i] = new ArrayList<Integer>();
+		}
+		StringTokenizer st = null;
+		for (int i = 0; i < N - 1; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			tree[a].add(b);
+			tree[b].add(a);
+		}
+
+		dfs(1, 0);
+		System.out.println(ans % 2 == 0 ? "No" : "Yes");
+	}
+
+	static void dfs(int num, int depth) {
+		visited[num] = true;
+		if (tree[num].size() == 1 && num != 1) { // 사이즈가 1이고 현재 num이 루트노드가 아니면 리프노드임
+			ans += depth; //지금까지 깊이 더해주기
+			return;
+		}
+
+		for (int i = 0; i < tree[num].size(); i++) {
+			int now = (int) tree[num].get(i);
+			if (!visited[now]) {
+				dfs(now, depth + 1);
+			}
+		}
+	}
+}

--- a/이화연/6주차/PGM_Level3_43162_네트워크.js
+++ b/이화연/6주차/PGM_Level3_43162_네트워크.js
@@ -1,0 +1,66 @@
+// union-find
+function solution(n, computers) {
+    let parents = new Array(n);
+    for(let i=0; i<n; i++){ //부모 자기 자신으로 세팅
+        parents[i] = i;
+    }
+    
+    const findParent = (num) => { // 부모찾기
+        if(parents[num] === num){
+            return num;
+        }
+        return parents[num] = findParent(parents[num]);
+    }
+    
+    const union = (a,b) => { // 하나로 합치기
+        let aRoot = findParent(a);
+        let bRoot = findParent(b);
+        if(aRoot !== bRoot){
+            parents[bRoot] = aRoot;
+        }
+    }
+    
+    for(let i=0; i<n; i++){
+        for(let j=0; j<n; j++){
+            if(i === j) continue; //자기자신은 제외
+            if(computers[i][j] === 1){ // 연결되어 있는 경우만 탐색
+                union(i,j);
+            }
+        }
+    }
+    
+    let set = new Set(); //중복제거하기 위해서
+    for(const p of parents){
+				// 위에서 for문을 돌며 부모를 찾았지만 최상단 부모까지 갱신되지 않은 경우를 제거해주기 위해 한번 더 부모 찾기
+        const realP = findParent(p); 
+        set.add(realP);
+    }
+    
+    return set.size;
+}
+
+// dfs
+function solution(n, computers) {
+    let answer = 0;
+    let visited = new Array(n).fill(false);
+    
+    const dfs = (i) => {
+        visited[i] = true;
+        
+        for(let j=0; j<n; j++){
+						// 자기 자신이 아니고 방문하지 않았고 연결되어 있을때
+            if(i != j && !visited[j] && computers[i][j] === 1){
+                dfs(j);
+            }
+        }
+    }
+    
+    for(let i=0; i<n; i++){
+        if(!visited[i]){
+            dfs(i);
+            answer++;
+        }
+    }
+ 
+    return answer;
+}


### PR DESCRIPTION
> ### [백준] 2138 전구와스위치
> - 난이도 : `골드4`
> - 알고리즘 유형 : `구현`
> - 내용
> ```
> 현재 자리는 현재 자리가 바뀌던가 다음 자리가 바꼈을때만 영향을 받으니
> - 0번째를 눌렀을때, 안눌렀을때를 각각 비교하기로 함 ⇒ 앞부터 똑같아야 하니까
> - 1 ~ N까지 현재 인덱스의 앞자리가 같은지 같지 않은지 비교
> 처음 풀이에서는 0~i-1, i-1, i, i+1, i+1~N 까지의 5개의 문자열을 매번 생성해서 붙여주면서 작업했더니 메모리 초과가 남
> - substring() 메서드를 사용했는데 새로운 문자열 객체를 Heap 영역에 생성하므로 메모리 낭비가 발생하며, 가비지 컬렉션이 처리해야 하는 작업이 늘어난다는 문제점 때문에 메모리 초과가 난듯
> - 또한 매번 새로운 String 객체를 생성한 것도 한 몫 한듯?
> 그래서 문자열을 배열로 바꿔서 계산했더니 통과함
> ```

<br/>

> ### [백준] 7490 0만들기
> - 난이도 : `골드5`
> - 알고리즘 유형 : `DFS` `완전탐색`
> - 내용
> ```
> DFS를 이용해서 공백, +, -를 붙이는 모든 경우 탐색
> 순서는 ASCII 순서를 따라 "공백 → + → -" 순으로 해줄 것
> ```

<br/>

> ### [백준] 13023 ABCDE
> - 난이도 : `골드5`
> - 알고리즘 유형 : `DFS`
> - 내용
> ```
> "A - B - C - D - E" 가 존재하는지 찾는 문제
>    - 즉, DFS를 수행했을 때 depth가 4이상이어야 한다.
> 모든 정점을 돌면서 DFS를 수행하고 depth가 4이상인 경우를 찾으면 다른 정점 탐색할 필요없이 return
>    - DFS에서 현재 정점에 연결된 정점이 1개 이상인 경우도 있기 때문에 방문처리를 false로 만드는 것도 필요함
> ```

<br/>

> ### [백준] 15900 나무탈출
> - 난이도 : `실버1`
> - 알고리즘 유형 : `트리`
> - 내용
> ```
> 1번 정점은 무조건 루트 노드고, 1번 정점을 제외한 정점 중 자식이 없는 경우 = 사이즈가 1인 경우는 리프 노드에 해당한다
> 리프 노드의 게임말을 루트 노드로 옮겨야 하니까 리프 노드와 루트 노드의 깊이를 구해주면 됨
> dfs이용해서 루트 노드인 1번 정점부터 시작해서 리프 노드를 만났을때 깊이를 더해준 후 총 깊이의 합이 짝수인 경우 형석이가 이기고 홀수인 경우 성원이가 이김
> ```

<br/>

> ### [프로그래머스] 43162 네트워크
> - 난이도 : `Level3`
> - 알고리즘 유형 : `DFS` `유니온파인드`
> - 내용
> ```
> 분류는 BFS/DFS로 되어 있으나 결국 연결되어 있으려면 루트노드가 다 똑같을것이라고 생각해 유니온파인드가 생각나 유니온파인드로 풀어봤다
> 일반적인 유니온파인드처럼 풀이해주면 되고 주의할 점은 마지막에 갱신된 부모 배열을 돌면서 한번 더 부모를 찾는 작업을 수행해줘야 한다는 점
> 그러나 DFS 푸는 것이 더 간단했다ㅎ
> ```
