### PR TITLE
0213 육다빈 5문제

### DIFF
--- a/육다빈/week6_0213/백준_1080_행렬.java
+++ b/육다빈/week6_0213/백준_1080_행렬.java
@@ -1,0 +1,42 @@
+package silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class S1080_matrix {
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		char[][] origin = new char[N][M];
+		for(int i=0; i<N; i++) origin[i] = br.readLine().toCharArray();
+
+		char[][] tobe = new char[N][M];
+		for(int i=0; i<N; i++) tobe[i] = br.readLine().toCharArray();
+		
+		int result = 0;
+		for(int i=0; i<N; i++) {
+			for(int j=0; j<M; j++) {
+				if(origin[i][j]==tobe[i][j]) continue;
+				else if(i+2>=N || j+2>=M) {
+					System.out.println(-1);
+					return;
+				}else {
+					result++;
+					for(int di=0; di<=2; di++) {
+						for(int dj=0; dj<=2; dj++) {
+							origin[i+di][j+dj] = (origin[i+di][j+dj]=='1' ? '0' : '1'); 
+						}
+					}
+				}
+			}
+		}
+		System.out.println(result);
+	}
+
+}

--- a/육다빈/week6_0213/백준_2138_전구와스위치.java
+++ b/육다빈/week6_0213/백준_2138_전구와스위치.java
@@ -1,0 +1,47 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class G2138_bulbAndSwitch {
+	static int N;
+	static char[] bulb;
+	
+	static void turn(int n) {
+		for(int i=-1; i<=1; i++) {
+			int now = n+i;
+			if(now<0 || now>=N) continue;
+			bulb[now] = (bulb[now]=='0') ? '1' : '0';
+		}
+	}
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		String origin = br.readLine();
+		char[] result = br.readLine().toCharArray();
+		
+		int cnt = Integer.MAX_VALUE;
+		for(int i=0; i<2; i++) {
+			bulb = origin.toCharArray();
+			int cnt_tmp = 0;
+			
+			if(i==1) {
+				cnt_tmp++;
+				turn(0);
+			}
+			
+			for(int j=1; j<N; j++) {
+				if(bulb[j-1] == result[j-1]) continue;
+				turn(j);
+				cnt_tmp++;
+			}
+			if(bulb[N-1] == result[N-1]) cnt = Math.min(cnt, cnt_tmp);
+		}
+		
+		System.out.println(cnt==Integer.MAX_VALUE ? -1 : cnt);
+	}
+
+}

--- a/육다빈/week6_0213/백준_7490_0만들기.java
+++ b/육다빈/week6_0213/백준_7490_0만들기.java
@@ -1,0 +1,38 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class G7490_makeZero {
+	static StringBuilder sb = new StringBuilder();
+	static int N;
+	
+	// n:연산할 수, sum:누적된 연산결과, pre:직전에 연산한 수, str:누적연산결과
+	static void makeZero(int n, int sum, int pre, String str) { 
+		if(n>N) {
+			if(sum==0) sb.append(str+"\n");
+			return;
+		}
+		
+		int tmp = (Math.abs(pre)*10 + n) * (pre>0 ? 1 : -1); // 앞에 수와 합쳐 만들어진 수
+		makeZero(n+1, sum-pre+tmp, tmp, str+" "+n); // 현재 수 붙이기
+		
+		makeZero(n+1, sum+n, n, str+"+"+n); // 현재 수 더하기
+		makeZero(n+1, sum-n, -n, str+"-"+n); // 현재 수 빼기
+	}
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		
+		for(int t=0; t<T; t++) {
+			N = Integer.parseInt(br.readLine());
+			if(t>0) sb.append("\n");
+			makeZero(2, 1, 1, "1");
+		}
+		
+		System.out.println(sb);
+	}
+
+}

--- a/육다빈/week6_0213/프로그래머스_12983_최고의집합.java
+++ b/육다빈/week6_0213/프로그래머스_12983_최고의집합.java
@@ -1,0 +1,50 @@
+import java.util.*;
+
+class Solution {
+    static class Node implements Comparable<Node>{
+        int multi;
+        List<Integer> list;
+        Node(int multi, List<Integer> list) {
+            this.multi = multi;
+            this.list = list;
+        }
+        @Override
+        public int compareTo(Node o){
+            return this.multi - o.multi;
+        }
+    }
+    public int[] solution(int n, int s) {
+        int[] answer;
+        if(s<n) {
+            answer = new int[] {-1};
+            return answer;
+        }
+        
+        Node[][] dp = new Node[n+1][s+1]; // n개의 원소로 만든 합이 s인 최고의 곱
+        for(int i=1; i<=s; i++){
+            dp[1][i] = new Node(i, Arrays.asList(i));
+        }
+        // int cnt = 0;
+        for(int i=2; i<=n; i++){
+            for(int j=i; j<=s; j++){
+                dp[i][j] = new Node(-1, new ArrayList<Integer>());
+                for(int k=1; k<j; k++){
+                    int tmp_mul = dp[i-1][j-k].multi * k;
+                    if(dp[i][j].multi < tmp_mul){
+                        ArrayList<Integer> tmp_list = new ArrayList<Integer>(dp[i-1][j-k].list);
+                        tmp_list.add(k);
+                        dp[i][j] = new Node(tmp_mul, tmp_list);
+                    }
+                }
+            }
+        }
+        
+            
+        int len = dp[n][s].list.size();
+        answer = new int[len];
+        int idx = 0;
+        for(int i : dp[n][s].list) answer[idx++] = i;
+        Arrays.sort(answer);
+        return answer;
+    }
+}

--- a/육다빈/week6_0213/프로그래머스_42583_다리를지나는트럭.java
+++ b/육다빈/week6_0213/프로그래머스_42583_다리를지나는트럭.java
@@ -1,0 +1,26 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int bridge_length, int weight, int[] truck_weights) {
+        Queue<Integer> queue = new LinkedList<Integer>();
+        int time=0, idx=0, cnt=0, remain_weight=weight, total=truck_weights.length;
+        while(cnt<total){
+            if(bridge_length<++time) {
+                int truck = queue.poll();
+                if(truck != -1){
+                    remain_weight += truck;
+                    cnt++;
+                }
+            }
+            if(idx<total){
+                if(truck_weights[idx]<=remain_weight) {
+                    remain_weight -= truck_weights[idx];
+                    queue.add(truck_weights[idx++]);
+                }else{
+                    queue.add(-1);
+                }
+            }
+        }
+        return time;
+    }
+}


### PR DESCRIPTION
> ### [백준] 2138 전구와 스위치
> - 난이도 : `골드 5`
> - 알고리즘 유형 : `그리디`
> - 내용
> ```
> 그리디임을 알아도 풀기 힘들었던 문제. 스위치를 누를 때 바뀌는 부분이 세군데인데, 
> 맨 앞과 맨 마지막 스위치를 누를 때는 두군데라서 풀기 어려웠다. 그냥 간단하게 맨 앞 스위치를 누르는 경우와 아닌경우 
> 두가지를 모두 해보고 앞에서부터 결과값에 맞게 스위치를 눌러가면 된다.
> ```

<br/>

> ### [백준] 7490 0 만들기
> - 난이도 : `골드 5`
> - 알고리즘 유형 : `BFS`, `브루트포스`
> - 내용
> ```
> 연산할 수가 최대 9를 넘지 않기에, 브루트포스로 모든 경우를 연산해도 시간초과 나지 않을것으로 생각하고 
> bfs로 모두 탐색하였다. 이전 숫자와 합치는 경우가 있어, 재귀로 풀이 시 직전 수에 대한 정보도 넘겨줘야 하는 문제.
> ```

<br/>

> ### [백준] 1080 행렬
> - 난이도 : `실버 1`
> - 알고리즘 유형 : `그리디`
> - 내용
> ```
> 이전에 풀려고 했다가 막혀서 다시 도전한 문제.
> 처음에는 각 자리마다 해당 자리를 중심으로 뒤집어야 할 자리의 개수를 저장하여, 
> 바뀌어야 할 부분이 가장 많이 뒤집히는 부분 순서대로 뒤집으려고 했다. 그런데 이 방법대로 하면,
> 뒤집힐때마다 변경되는 부분들을 계속 바꿔줘야 하는 점에서 모든 변경점을 관리하기가 은근 까다로웠고
> 다시 생각해보니 앞에서부터 바꿔야 할 부분이 있으면 뒤집고 다시 보지 않는 방식으로 풀어도 되더라는,,
> 행렬의 최대 길이가 길지 않아 그리디로 풀 수 있었던 문제.
> ```

<br/>

> ### [프로그래머스] 42583 다리를 지나는 트럭
> - 난이도 : `Lv 2`
> - 알고리즘 유형 : `자료구조`
> - 내용
> ```
> 큐에 매 초마다 순서가 된 트럭이 들어올 수 있으면 넣고 아니면 -1을 넣어서,
> 큐의 길이가 다리 길이만큼 되었을 때마다 맨 앞의 값을 빼는 방식으로 풀었다.
> ```

<br/>

> ### [프로그래머스] 12983 최고의 집합 (실패)
> - 난이도 : `Lv 3`
> - 알고리즘 유형 : `-`
> - 내용
> ```
> DP로 풀었는데 메모리초과 났습니다,, 날만하긴 했는데 어떻게 풀어야 할지 감이 안와요
> ```





