### PR TITLE
0220 육다빈 5문제

### DIFF
--- a/육다빈/week7_0220/백준_11000_강의실배정.java
+++ b/육다빈/week7_0220/백준_11000_강의실배정.java
@@ -1,0 +1,53 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class G11000_classroomAssignment {
+	
+	static class Class implements Comparable<Class>{
+		int start, end;
+		Class(int start, int end){
+			this.start = start;
+			this.end = end;
+		}
+		@Override
+		public int compareTo(Class o) {
+			return this.start - o.start;
+		}
+	}
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		
+		Class[] classList = new Class[N];
+		for(int i=0; i<N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int start = Integer.parseInt(st.nextToken());
+			int end = Integer.parseInt(st.nextToken());
+			classList[i] = new Class(start, end);
+		}
+		
+		Arrays.sort(classList);
+		
+		PriorityQueue<Integer> queue = new PriorityQueue<Integer>();
+		queue.add(0);
+		int cnt = 1;
+		for(int i=0; i<N; i++) {
+			if(queue.peek() <= classList[i].start) {
+				queue.poll();
+			}else {
+				cnt++;
+			}
+			queue.add(classList[i].end);
+		}
+		
+		System.out.println(cnt);
+	}
+
+}

--- a/육다빈/week7_0220/백준_14699_관악산등산.java
+++ b/육다빈/week7_0220/백준_14699_관악산등산.java
@@ -1,0 +1,92 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class G14699_mountainClimbing {
+	static int[] height, result;
+	static List<Integer>[] edges;
+	
+	static class Node implements Comparable<Node>{
+		int idx, height; // idx:쉼터번호, height:높이, shelter:오를 수 있는 최대 쉼터 수
+		
+		Node(int idx, int height){
+			this.idx = idx;
+			this.height = height;
+		}
+		@Override
+		public int compareTo(Node o) { // 오름차순 정렬
+			return o.height - this.height;
+		}
+		
+	}
+	
+	static void bfs(int start) {
+		result[start] = 1;
+		Queue<Integer> queue = new LinkedList<Integer>();
+		queue.add(start);
+		
+		int cnt = 1;
+		while(!queue.isEmpty()) {
+			cnt++;
+			int size = queue.size();
+			
+			for(int s=0; s<size; s++) {
+				int now = queue.poll();
+				
+				for(int n : edges[now]) {
+					if(height[n]<height[now] && result[n]<cnt) {
+						result[n] = cnt;
+						queue.add(n);
+					}
+				}
+				
+			}
+		}
+	}
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		Node[] nodes = new Node[N];
+		height = new int[N+1];
+		edges = new List[N+1];
+
+		st = new StringTokenizer(br.readLine());
+		for(int i=0; i<N; i++) {
+			int h = Integer.parseInt(st.nextToken());
+			nodes[i] = new Node(i+1, h);
+			height[i+1] = h;
+			edges[i+1] = new ArrayList<Integer>();
+		}
+		
+		Arrays.sort(nodes);
+		
+		for(int i=0; i<M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			edges[a].add(b);
+			edges[b].add(a);
+		}
+		
+		result = new int[N+1];
+		for(int i=0; i<N; i++) {
+			if(result[nodes[i].idx]==0) bfs(nodes[i].idx);
+		}
+		
+		StringBuilder sb = new StringBuilder();
+		for(int i=1; i<=N; i++) sb.append(result[i]+"\n");
+		System.out.println(sb);
+	}
+
+}

--- a/육다빈/week7_0220/백준_24230_트리색칠하기.java
+++ b/육다빈/week7_0220/백준_24230_트리색칠하기.java
@@ -1,0 +1,55 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class G24230_paintingTree {
+	static int N, cnt=0;
+	static int[] answer;
+	static List<Integer>[] nodes;
+	static boolean[] visit;
+	
+	static void dfs(int node, int color) {
+		visit[node] = true;
+		int paint = color;
+		if(answer[node] != color) {
+			paint = answer[node];
+			cnt++;
+		}
+		for(int n : nodes[node]) {
+			if(!visit[n]) dfs(n, paint);
+		}
+	}
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		answer = new int[N+1];
+		nodes = new List[N+1];
+		visit = new boolean[N+1];
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for(int i=1; i<=N; i++) {
+			answer[i] = Integer.parseInt(st.nextToken());
+			nodes[i] = new ArrayList<Integer>();
+		}
+		
+		for(int i=0; i<N-1; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			nodes[a].add(b);
+			nodes[b].add(a);
+		}
+		
+		dfs(1, 0);
+		
+		System.out.println(cnt);
+		
+	}
+
+}

--- a/육다빈/week7_0220/백준_5549_행성탐사.java
+++ b/육다빈/week7_0220/백준_5549_행성탐사.java
@@ -1,0 +1,57 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class G5549_goPlanet {
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		int K = Integer.parseInt(br.readLine());
+		
+		char[][] map = new char[N][M];
+		for(int i=0; i<N; i++) map[i] = br.readLine().toCharArray();
+		
+		int[][][] sum = new int[3][N][M];
+		for(int i=0; i<N; i++) {
+			int[] tmp = new int[3];
+			for(int j=0; j<M; j++) {
+				int idx = (map[i][j]=='J' ? 0 : (map[i][j]=='O'?1:2));
+				tmp[idx]++;
+				for(int t=0; t<3; t++) {
+					if(i==0) sum[t][i][j] = tmp[t];
+					else sum[t][i][j] = sum[t][i-1][j]+tmp[t];
+				}
+			}
+		}
+
+		StringBuilder sb = new StringBuilder();
+		for(int k=0; k<K; k++) {
+			st = new StringTokenizer(br.readLine());
+			int si = Integer.parseInt(st.nextToken())-2;
+			int sj = Integer.parseInt(st.nextToken())-2;
+			int ei = Integer.parseInt(st.nextToken())-1;
+			int ej= Integer.parseInt(st.nextToken())-1;
+			int tmp[] = new int[3];
+			for(int t=0; t<3; t++) {
+				if(si<0) {
+					if(sj<0) tmp[t] = sum[t][ei][ej];
+					else tmp[t] = sum[t][ei][ej] - sum[t][ei][sj];
+				}else {
+					if(sj<0) tmp[t] = sum[t][ei][ej] - sum[t][si][ej];
+					else tmp[t] = sum[t][ei][ej] - sum[t][si][ej] - sum[t][ei][sj] + sum[t][si][sj];
+				}
+				sb.append(tmp[t]);
+				sb.append(t==2 ? '\n' : ' ');
+			}
+		}
+		
+		System.out.println(sb);
+	}
+
+}

--- a/육다빈/week7_0220/프로그래머스_12981_영어끝말잇기.java
+++ b/육다빈/week7_0220/프로그래머스_12981_영어끝말잇기.java
@@ -1,0 +1,27 @@
+import java.util.*;
+
+class Solution {
+    public int[] solution(int n, String[] words) {
+        
+        int answer[] = new int[2];
+        Set<String> set = new HashSet<String>();
+        char pre = words[0].charAt(words[0].length()-1);
+        int len = words.length, idx=1;
+        set.add(words[0]);
+        answer[0]=1;
+        for(int i=1; i<len; i++){
+            if(set.contains(words[i]) || words[i].length()<=1 || pre!=words[i].charAt(0)){
+                answer[0]++;
+                answer[1] = i/n + 1;
+                return answer;
+            }else{
+                answer[0] = (answer[0]+1)%n;
+                set.add(words[i]);
+                pre = words[i].charAt(words[i].length()-1);
+            }
+        }
+        
+        answer[0] = answer[1] = 0;
+        return answer;
+    }
+}


### PR DESCRIPTION
> ### [백준] 14699 관악산 등산
> - 난이도 : `골드 5`
> - 알고리즘 유형 : `트리`, `BFS`
> - 내용
> ```
> 가장 높은 쉼터에서부터 시작해서 더 낮은 쉼터로 내려가며 각 쉼터의 최대 방문횟수를 계산했다.
> 최대 방문횟수를 저장할 result 배열을 만들고, 가장 높은 쉼터부터 방문해서 해당 쉼터의 result값이 0이면 
> 그 쉼터와 연결된 더 낮은 쉼터들을 bfs로 찾아 각 쉼터의 result값을 넣는다.
> 낮은 쉼터 중 이미 방문한 쉼터에 대하여, 이번 방문횟수가 더 큰 경우에는 그 하위의 쉼터들도 다시 값을 갱신해줘야 한다.
> ```

<br/>

> ### [백준] 24230 트리 색칠하기
> - 난이도 : `골드 5`
> - 알고리즘 유형 : `트리`, `DFS`
> - 내용
> ```
> 상위 노드를 색칠하면 하위노드들까지 모두 색칠되므로, 상위 색과 다른 색인 하위 노드들에 대해서만
>  색을 다시 칠해주면 되기에 dfs로 탐색하며 그 횟수를 세어 주었다. 상위노드의 색과, 정답지 색 정보만 알면 
> 색을 칠하는 횟수를 구할수 있기에, 현재 노드들의 색 상태는 따로 저장할 필요가 없었다.
> ```

<br/>

> ### [백준] 5549 행성탐사
> - 난이도 : `골드 5`
> - 알고리즘 유형 : `누적 `
> - 내용
> ```
> 지도에서 (0, 0)에서부터 해당 구역까지 각 지형의 누적합을 순차적으로 계산하고, 조사대상 영역이 주어지면 (0,0)에서 
> 조사대상 범위까지 넓이에서 대상이 아닌 범위들을 빼주는 방식으로 풀었다.
> 처음에 전체 맵에서 일부분의 누적합을 다 계산하기엔 조사 대상 영역 개수가 많아서 시간초과 날 것이라 생각했는데, 
> 누적합을 어떻게 써야할지 생각해내는데 조금 걸렸다.
> ```

<br/>

> ### [백준] 11000 강의실 배정
> - 난이도 : `골드 5`
> - 알고리즘 유형 : `그리디`, 자료구조
> - 내용
> ```
> 강의실 정보를 수업 시작시간 기준으로 오름차순 정렬하고, 앞에서부터 사용가능한 강의실이 없으면
> 강의실을 추가하는 식으로 풀었다. 우선순위 큐에 강의실의 수업이 끝나는 시간들만 저장하여, 
> 가장 수업이 빨리 끝날 강의실을 우선으로 배정해주도록 하였다.
> ```

<br/>

> ### [프로그래머스] 12981 영어 끝말잇기
> - 난이도 : `Lv 2`
> - 알고리즘 유형 : `자료구조`
> - 내용
> ```
> Set을 사용해서 언급된 단어를 저장하고, 매 차례마다 중복값을 말하는지와 이전 단어 끝글자로 시작하는지만
> 확인하면 되는 문제
> ```








