### PR TITLE
0227 조민규 5문제

### DIFF
--- a/조민규/DFS및BFS/bj14267_회사문화1.java
+++ b/조민규/DFS및BFS/bj14267_회사문화1.java
@@ -1,0 +1,56 @@
+package DP;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class bj14267_회사문화1 {
+    static int N, M;
+    static int[] goodCount;
+    static List<Integer>[] worker;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        // 입력 1
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        goodCount = new int[N+1];
+        worker = new ArrayList[N+1];
+        for(int i = 1 ; i <= N ; i++){
+            worker[i] = new ArrayList<>();
+        }
+        // 입력 2
+        st = new StringTokenizer(br.readLine());
+        Integer.parseInt(st.nextToken());
+        for (int i = 2 ; i <= N ; i++){
+            worker[Integer.parseInt(st.nextToken())].add(i);
+        }
+        // 입력 3~5
+        for(int i = 0 ; i < M ; i++){
+            st = new StringTokenizer(br.readLine());
+            int who = Integer.parseInt(st.nextToken());
+            int weight = Integer.parseInt(st.nextToken());
+            goodCount[who] += weight;
+        }
+
+        dfs(1);
+
+        // 출력
+        for(int i = 1 ; i < goodCount.length ; i++){
+            System.out.print(goodCount[i] + " ");
+        }
+        System.out.println();
+    }
+
+    // 내리 더해주기
+    public static void dfs(int now){
+        // 현재 내가 가지고 있는 직속부하들에게 내 칭찬점수를 더해준다.
+        for(int w : worker[now]){
+            goodCount[w] += goodCount[now];
+            dfs(w);
+        }
+    }
+}

--- a/조민규/DFS및BFS/bj2606_바이러스.java
+++ b/조민규/DFS및BFS/bj2606_바이러스.java
@@ -1,0 +1,51 @@
+package DFS및BFS;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class bj2606_바이러스 {
+    static int N, M; // 노드 갯수, 간선 갯수
+    static int[][] adjMatrix;
+    static int ans = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        M = Integer.parseInt(br.readLine());
+        adjMatrix = new int[N+1][N+1];
+        for(int i = 0 ; i < M ; i++){
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            adjMatrix[a][b] = 1;
+            adjMatrix[b][a] = 1;
+        }
+
+        bfs(1);
+        System.out.println(ans);
+    }
+
+    public static void bfs(int start){
+        Queue<Integer> queue = new LinkedList<>();
+        queue.add(start);
+
+        boolean[] visited = new boolean[N+1];
+        visited[start] = true;
+
+        while(!queue.isEmpty()){
+            int now = queue.poll();
+
+            for(int i = 2 ; i <= N ; i++){
+                if(i != now && !visited[i] && adjMatrix[now][i] == 1){
+                    visited[i] = true;
+                    ans += 1;
+                    queue.add(i);
+                }
+            }
+        }
+    }
+}

--- a/조민규/DFS및BFS/bj4179_불.java
+++ b/조민규/DFS및BFS/bj4179_불.java
@@ -42,7 +42,6 @@ public class bj4179_불 {
                 if(map[i][j] == 'J'){
                     x = i;
                     y = j;
-                    //map[i][j] = '.';
                 }
                 // 불일 경우
                 if(map[i][j] == 'F'){
@@ -68,13 +67,35 @@ public class bj4179_불 {
         Queue<Point> queue = new LinkedList<>(); // 지훈의 위치 큐
         queue.add(new Point(x,y, 1)); // 지훈 초기 위치 및 시간 설정
         boolean[][] visited = new boolean[R][C]; // 지훈의 방문 체크 배열
+        visited[x][y] = true;
 
         // BFS
         while (!queue.isEmpty()){
 
             // 지훈이의 새 위치
-            Point point = queue.poll();
-            visited[point.x][point.y] = true;
+            int size = queue.size();
+            for(int s = 0 ; s < size ; s++){
+                Point point = queue.poll();
+                if(map[point.x][point.y] == 'F'){
+                    continue;
+                }
+
+                // 지훈이가 이동 가능한 새 위치 탐색
+                for(int d = 0 ; d < 4 ; d++){
+                    int nX = point.x + di[d];
+                    int nY = point.y + dj[d];
+
+                    if(isValid(nX, nY) && !visited[nX][nY]) {
+                        queue.add(new Point(nX, nY,  point.time + 1));
+                        visited[nX][nY] = true;
+                    }
+                }
+
+                // 지훈이가 탈출 가능한가?
+                if(isBreak(point.x,point.y)){
+                    ans = Math.min(ans, point.time);
+                }
+            }
 
             // 불 확산
             Queue<Point> newFires = new LinkedList<>();
@@ -91,26 +112,7 @@ public class bj4179_불 {
                 }
             }
             fires = new LinkedList<>(newFires);
-
-            showMap(map, point);
-
-            // 지훈이가 탈출 가능한가?
-            if(isBreak(point.x,point.y)){
-                ans = Math.min(ans, point.time);
-                continue; // 여기서 새 위치를 탐색하는 것은 어차피 시간이 더 걸리는 행위므로
-            }
-
-            // 지훈이가 이동 가능한 새 위치 탐색
-            for(int d = 0 ; d < 4 ; d++){
-                int nX = point.x + di[d];
-                int nY = point.y + dj[d];
-
-                if(isValid(nX, nY) && !visited[nX][nY]) {
-                    queue.add(new Point(nX, nY,  point.time + 1));
-                }
-            }
         }
-
     }
 
     public static boolean isValid(int x, int y){
@@ -119,19 +121,5 @@ public class bj4179_불 {
 
     public static boolean isBreak(int x, int y){
         return x == 0 || x == R-1 || y == 0 || y == C-1;
-    }
-
-
-    public static void showMap(char[][] map, Point point){
-        System.out.println("\n==========");
-        System.out.println("* 위치 : (" + point.x + "," + point.y + ")");
-        System.out.println("* 시간 : " + point.time);
-        for(int i = 0 ; i < map.length ; i++){
-            for(int j = 0 ; j < map[i].length ; j++){
-                System.out.print(map[i][j]);
-            }
-            System.out.println();
-        }
-        System.out.println("==========");
     }
 }

--- a/조민규/DFS및BFS/bj4179_불.java
+++ b/조민규/DFS및BFS/bj4179_불.java
@@ -1,0 +1,137 @@
+package DFS및BFS;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class bj4179_불 {
+    static class Point {
+        int x, y, time;
+
+        public Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        public Point(int x, int y, int time) {
+            this.x = x;
+            this.y = y;
+            this.time = time;
+        }
+    }
+    static int R,C, ans = Integer.MAX_VALUE;
+    static char[][] map;
+    static int[] di = {0,0,-1,1};
+    static int[] dj = {1,-1,0,0};
+
+    public static void main(String[] args) throws IOException {
+        // 입력
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        R = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+        map = new char[R][C];
+        Queue<Point> fires = new LinkedList<>();
+        int x = 0, y = 0;
+        for(int i = 0 ; i < R ; i++){
+            String str = br.readLine();
+            for(int j = 0 ; j < C ; j++){
+                map[i][j] = str.charAt(j);
+                // 지훈이일 경우
+                if(map[i][j] == 'J'){
+                    x = i;
+                    y = j;
+                    //map[i][j] = '.';
+                }
+                // 불일 경우
+                if(map[i][j] == 'F'){
+                    fires.add(new Point(i,j));
+                }
+            }
+        }
+
+        // 이미 탈출 가능한 위치일 경우
+        if(isBreak(x, y)){
+            System.out.println(1);
+            return;
+        }
+
+        // BFS
+        bfs(x,y,fires);
+        System.out.println(ans == Integer.MAX_VALUE ? "IMPOSSIBLE" : ans);
+    }
+
+    // x,y : 지훈 초기 위치 , fires : 현재 불 위치 담는 큐
+    public static void bfs(int x, int y, Queue<Point> fires){
+        
+        Queue<Point> queue = new LinkedList<>(); // 지훈의 위치 큐
+        queue.add(new Point(x,y, 1)); // 지훈 초기 위치 및 시간 설정
+        boolean[][] visited = new boolean[R][C]; // 지훈의 방문 체크 배열
+
+        // BFS
+        while (!queue.isEmpty()){
+
+            // 지훈이의 새 위치
+            Point point = queue.poll();
+            visited[point.x][point.y] = true;
+
+            // 불 확산
+            Queue<Point> newFires = new LinkedList<>();
+            while(!fires.isEmpty()){
+                Point fire = fires.poll();
+                for(int d = 0 ; d < 4 ; d++){
+                    int nX = fire.x + di[d];
+                    int nY = fire.y + dj[d];
+
+                    if(isValid(nX, nY)){
+                        map[nX][nY] = 'F';
+                        newFires.add(new Point(nX, nY));
+                    }
+                }
+            }
+            fires = new LinkedList<>(newFires);
+
+            showMap(map, point);
+
+            // 지훈이가 탈출 가능한가?
+            if(isBreak(point.x,point.y)){
+                ans = Math.min(ans, point.time);
+                continue; // 여기서 새 위치를 탐색하는 것은 어차피 시간이 더 걸리는 행위므로
+            }
+
+            // 지훈이가 이동 가능한 새 위치 탐색
+            for(int d = 0 ; d < 4 ; d++){
+                int nX = point.x + di[d];
+                int nY = point.y + dj[d];
+
+                if(isValid(nX, nY) && !visited[nX][nY]) {
+                    queue.add(new Point(nX, nY,  point.time + 1));
+                }
+            }
+        }
+
+    }
+
+    public static boolean isValid(int x, int y){
+        return x >= 0 && x < R && y >= 0 && y < C && map[x][y] != '#' && map[x][y] != 'F';
+    }
+
+    public static boolean isBreak(int x, int y){
+        return x == 0 || x == R-1 || y == 0 || y == C-1;
+    }
+
+
+    public static void showMap(char[][] map, Point point){
+        System.out.println("\n==========");
+        System.out.println("* 위치 : (" + point.x + "," + point.y + ")");
+        System.out.println("* 시간 : " + point.time);
+        for(int i = 0 ; i < map.length ; i++){
+            for(int j = 0 ; j < map[i].length ; j++){
+                System.out.print(map[i][j]);
+            }
+            System.out.println();
+        }
+        System.out.println("==========");
+    }
+}

--- a/조민규/DP/bj1003_피보나치함수.java
+++ b/조민규/DP/bj1003_피보나치함수.java
@@ -1,0 +1,38 @@
+package DP;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class bj1003_피보나치함수 {
+    static int N;
+    static int[][] dp;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        for(int t = 1 ; t <= T ; t++){
+            N = Integer.parseInt(br.readLine());
+            dp = new int[41][2];
+
+            dp[0][0] = 1;
+            dp[0][1] = 0;
+            dp[1][0] = 0;
+            dp[1][1] = 1;
+
+            fibonacci(N);
+            System.out.println(dp[N][0] + " " + dp[N][1]);
+        }
+    }
+
+    public static int[] fibonacci(int n){
+
+        if(dp[n][0] == 0 && n >= 2){
+            int[] f1 = fibonacci(n-1);
+            int[] f2 = fibonacci(n-2);
+            dp[n][0] = f1[0] + f2[0];
+            dp[n][1] = f1[1] + f2[1];
+        }
+
+        return dp[n];
+    }
+}

--- a/조민규/재귀/bj2630_색종이만들기.java
+++ b/조민규/재귀/bj2630_색종이만들기.java
@@ -1,0 +1,55 @@
+package 재귀;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class bj2630_색종이만들기 {
+    static int N; // 종이 한 변의 길이
+    static int ans[] = new int[2];
+    static int[][] map; // 색종이
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        map = new int[N][N];
+        for(int i = 0 ; i < N ; i++){
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for(int j = 0 ; j < N ; j++){
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        cutPaper(0, 0, N);
+        System.out.println(ans[0]);
+        System.out.println(ans[1]);
+    }
+
+    public static void cutPaper(int startX, int startY, int len){
+        // 색이 전체 동일한지 검사한다.
+        int originColor = map[startX][startY];
+        boolean isSame = true;
+        for(int i = startX ; i < startX + len ; i++){
+            for(int j = startY ; j < startY + len ; j++){
+                if(map[i][j] != originColor){
+                    isSame = false;
+                    break;
+                }
+            }
+            if(!isSame) break;
+        }
+
+        // 동일하면, 해당값++
+        if(isSame) {
+            ans[originColor]++;
+            return;
+        }
+
+        // 동일하지 않으면, 4개로 나눈다.
+        int newLen = len / 2;
+        cutPaper(startX, startY, newLen);
+        cutPaper(startX + newLen, startY, newLen);
+        cutPaper(startX, startY + newLen, newLen);
+        cutPaper(startX + newLen, startY + newLen, newLen);
+    }
+}


### PR DESCRIPTION
> ### [백준] 1003 피보나치 함수
> - 난이도 : `실버3`
> - 알고리즘 유형 : `DP`
> - 내용
> ```
> 피보나치 값을 구하는 것이 아닌 0과 1의 호출 횟수를 구해야 하는 문제.
> dp[41][2] 배열의 dp[i][0], dp[i][1]에 각각 해당하는 수의 0과 1 호출 횟수를 저장한다.
> ```

<br/>

> ### [백준] 2630 색종이 만들기
> - 난이도 : `실버2`
> - 알고리즘 유형 : `재귀`
> - 내용
> ```
> 입력한 원본 map을 기준으로 기준 시작점, 길이를 가지고 재귀 함수를 구현하였다.
> 4분할 재귀 문제
> ```

<br/>

> ### [백준] 14267 회사 문화 1
> - 난이도 : `골4`
> - 알고리즘 유형 : `DFS`
> - 내용
> ```
> 제일 위부터 아래에 있는 모든 직속부하들에게 자신이 가진 칭찬횟수를 더해주며 나가면 된다.
> ```
![image](https://user-images.githubusercontent.com/64128134/222974793-33500087-76e0-4296-8bcd-2e89f3b13b5d.png)


<br/>

> ### [백준] 4179 불! (F)
> - 난이도 : `골드4`
> - 알고리즘 유형 : `BFS`
> - 내용
> ```
> 지훈이의 위치를 담은 큐 queue,  최근 불의 위치들을 담은 큐 fires 두 개를 이용해 BFS를 구현했다.
> 예제 및 게시판의 반례들도 모두 맞는데 왜 2%에서 틀린거지...
> ```

<br/>

> ### [백준] 2606 바이러스
> - 난이도 : `실버3`
> - 알고리즘 유형 : `BFS`
> - 내용
> ```
> 처음엔 DFS로 풀려 했으나 시간초과 났다.
> 최대로 지나간 갯수를 출력하는 것이 아닌 BFS로 방문 가능한 모든 노드의 갯수를 출력한다.
> ```
