### PR TITLE
0306 이화연 5문제

### DIFF
--- a/이화연/9주차/BOJ_Gold3_11437_LCA.java
+++ b/이화연/9주차/BOJ_Gold3_11437_LCA.java
@@ -1,0 +1,83 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class BOJ_Gold3_11437_LCA {
+	static int N, parent[], depth[], M;
+	static ArrayList<Integer>[] list;
+	static boolean[] visited;
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		list = new ArrayList[N + 1];
+		visited = new boolean[N + 1];
+		parent = new int[N + 1]; // 각 노드의 부모
+		depth = new int[N + 1]; // 각 노드의 depth
+
+		for (int i = 1; i <= N; i++) {
+			list[i] = new ArrayList<>();
+		}
+
+		StringTokenizer st = null;
+		for (int i = 0; i < N - 1; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			list[a].add(b);
+			list[b].add(a);
+		}
+
+		visited[1] = true;
+		dfs(1, 1, 1); // 루트노드인 1부터 시작
+
+		M = Integer.parseInt(br.readLine());
+		for (int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			System.out.println(findCommonParent(a, b));
+		}
+
+	}
+
+	static void dfs(int num, int p, int d) { // 각 노드의 깊이, 부모 찾기
+		depth[num] = d;
+		parent[num] = p;
+
+		if (list[num].size() == 1 && num != 1) { // 사이즈가 1이고 루트노드가 아니면 리프노드임
+			return;
+		}
+
+		for (int next : list[num]) {
+			if (!visited[next]) {
+				visited[next] = true;
+				dfs(next, num, d + 1);
+			}
+		}
+	}
+
+	static int findCommonParent(int a, int b) {
+		int depthA = depth[a];
+		int depthB = depth[b];
+
+		while (depthA != depthB) { // 깊이를 같게 만들기
+			if (depthA > depthB) {
+				a = parent[a]; // a의 깊이를 줄였으니 그 위 부모로 갱신
+				depthA--;
+			} else {
+				b = parent[b];
+				depthB--;
+			}
+		}
+
+		while (a != b) { // 깊이는 같으니 공통 부모 찾기
+			a = parent[a];
+			b = parent[b];
+		}
+
+		return a;
+	}
+}

--- a/이화연/9주차/BOJ_Gold4_3584_가장가까운공통조상.java
+++ b/이화연/9주차/BOJ_Gold4_3584_가장가까운공통조상.java
@@ -1,0 +1,71 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_Gold4_3584_가장가까운공통조상 {
+	static int N;
+	static ArrayList<Integer>[] list;
+	static ArrayList<Integer> aList, bList;
+	static boolean[] visited;
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine()); // 테케
+
+		for (int t = 0; t < T; t++) {
+			N = Integer.parseInt(br.readLine());
+			list = new ArrayList[N + 1];
+
+			for (int i = 1; i <= N; i++) {
+				list[i] = new ArrayList<>();
+			}
+
+			StringTokenizer st = null;
+			for (int i = 0; i < N - 1; i++) { // 간선 연결
+				st = new StringTokenizer(br.readLine());
+				int a = Integer.parseInt(st.nextToken());
+				int b = Integer.parseInt(st.nextToken());
+				list[b].add(a); // 자식 -> 부모
+			}
+
+			st = new StringTokenizer(br.readLine());
+			int A = Integer.parseInt(st.nextToken()); // 가장 가까운 공통 조상 구할 노드
+			int B = Integer.parseInt(st.nextToken());
+
+			visited = new boolean[N + 1]; // 해당 정점 방문했는지
+			int ans = 0; // 공통 조상 노드
+
+			Queue<Integer> queue = new LinkedList<>();
+			queue.add(A);
+			visited[A] = true;
+			while (!queue.isEmpty()) { // A노드는 모든 조상을 찾아서 방문처리
+				int now = queue.poll();
+
+				for (int next : list[now]) {
+					queue.add(next);
+					visited[next] = true;
+				}
+			}
+
+			queue.add(B);
+			while (true) {
+				int now = queue.poll();
+				if (visited[now]) { // 방문했다 = 공통 조상 발견
+					ans = now;
+					break;
+				} else { // 방문안한 조상 노드는 방문처리
+					visited[now] = true;
+				}
+				for (int next : list[now]) {
+					queue.add(next);
+				}
+			}
+			System.out.println(ans);
+
+		}
+	}
+}

--- a/이화연/9주차/BOJ_Gold4_4803_트리.java
+++ b/이화연/9주차/BOJ_Gold4_4803_트리.java
@@ -1,0 +1,90 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class BOJ_Gold4_4803_트리 {
+	static int n, m, parent[];
+	static boolean noTree[];
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = null;
+		int index = 1;
+		while (true) {
+			st = new StringTokenizer(br.readLine());
+			n = Integer.parseInt(st.nextToken()); // 정점 개수
+			m = Integer.parseInt(st.nextToken()); // 간선 개수
+			if (n == 0 && m == 0) {
+				break;
+			}
+
+			parent = new int[n + 1];
+			noTree = new boolean[n + 1];
+			setParent();
+
+			for (int i = 0; i < m; i++) {
+				st = new StringTokenizer(br.readLine());
+				int a = Integer.parseInt(st.nextToken());
+				int b = Integer.parseInt(st.nextToken());
+				if (!union(a, b)) { // 사이클 생긴 경우
+					noTree[parent[a]] = true;
+				}
+			}
+
+			// 자신의 부모가 최상위 루트로 갱신되지 않은 정점들이 있을 수 있으니 다시 한번 부모 찾기
+			for (int i = 1; i <= n; i++) {
+				findParent(i);
+				// 이미 사이클이 생겼던 부모의 최상위 루트가 바꼈을경우 그 최상위 루트도 사이클 처리해줘야 함
+				if (noTree[i]) {
+					noTree[parent[i]] = true;
+				}
+			}
+
+			Set<Integer> set = new HashSet<>();
+			for (int i = 1; i <= n; i++) {
+				if (!noTree[parent[i]]) { // 사이클 안생긴 루트정점만 담기
+					set.add(parent[i]);
+				}
+			}
+
+			if (set.size() == 0) {
+				System.out.println("Case " + index + ": No trees.");
+			} else if (set.size() == 1) {
+				System.out.println("Case " + index + ": There is one tree.");
+			} else {
+				System.out.println("Case " + index + ": A forest of " + set.size() + " trees.");
+			}
+			index++;
+		}
+
+	}
+
+	static void setParent() { // 자기 자신으로 부모 세팅
+		for (int i = 1; i <= n; i++) {
+			parent[i] = i;
+		}
+	}
+
+	static int findParent(int num) {
+		if (num == parent[num]) {
+			return num;
+		}
+		return parent[num] = findParent(parent[num]);
+	}
+
+	static boolean union(int a, int b) {
+		int aRoot = findParent(a);
+		int bRoot = findParent(b);
+		if (aRoot == bRoot) {
+			return false;
+		}
+
+		parent[bRoot] = aRoot;
+		return true;
+	}
+
+}

--- a/이화연/9주차/BOJ_Silver2_1541_잃어버린괄호.java
+++ b/이화연/9주차/BOJ_Silver2_1541_잃어버린괄호.java
@@ -1,0 +1,27 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_Silver2_1541_잃어버린괄호 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		String[] str = br.readLine().split("-"); // 뺄셈으로 분리
+
+		int ans = 0;
+		for (int i = 0; i < str.length; i++) {
+			String[] divide = str[i].split("\\+"); // 덧셈으로 분리
+			int sum = 0;
+			for (int j = 0; j < divide.length; j++) {
+				sum += Integer.parseInt(divide[j]);
+			}
+
+			if (i == 0) {
+				ans = sum;
+			} else {
+				ans -= sum;
+			}
+		}
+		System.out.println(ans);
+	}
+}

--- a/이화연/9주차/PGM_Level2_42586_기능개발.java
+++ b/이화연/9주차/PGM_Level2_42586_기능개발.java
@@ -1,0 +1,33 @@
+import java.util.*;
+
+class Solution {
+    public int[] solution(int[] progresses, int[] speeds) {
+        ArrayList<Integer> list = new ArrayList<Integer>();
+        
+        Queue<Integer> queue = new LinkedList<Integer>();
+        for(int i=0; i<speeds.length; i++){
+            int temp = (int)Math.ceil((double)(100 - progresses[i])/speeds[i]);
+            queue.add(temp);
+        }
+        
+        int before = queue.poll();
+        int idx = 0;
+        list.add(1);
+        while(!queue.isEmpty()){
+            int now = queue.poll();
+            if(now > before){
+                idx++;
+                before = now;
+                list.add(1);
+            }else{
+                list.set(idx, list.get(idx)+1);
+            }
+        }
+        
+        int[] answer = new int[list.size()];
+        for(int i=0; i<list.size(); i++){
+            answer[i] = list.get(i);
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
> ### [백준] 4803 트리
> - 난이도 : `골드4`
> - 알고리즘 유형 : `트리`
> - 내용
> ```
> 유니온 파인드 이용해서 문제를 풀이했는데 처음에 8%에서 틀렸습니다가 나왔다
> 질문게시판의 반례를 해본 결과 간선이 입력되면서 찾은 부모정점이 최상위 부모가 아닐 수 있다는 점
```
4 4
2 3
2 4
3 4
1 2
0 0
```
> ```
> 위와 같은 경우에는 입력되는 간선마다 유니온파인드를 실행하고 나면 각 정점의 부모가 [1,1,2,2]로 갱신된다
> 하지만 정점 2의 최상위 부모는 1이기 때문에 최종적으로 [1,1,1,1]의 형태가 나와야 하는 것
> 따라서 각 정점에 findParent(n)를 수행해서 최상위 부모를 찾아주는 작업을 한 번 더 수행해줘야 한다
> 최상위 부모 정점의 개수가 최종 트리의 수이기 때문에 set을 이용해서 중복을 제거해서 담아줬다
> ```

<br/>

> ### [백준] 3584 가장가까운공통조상
> - 난이도 : `골드4`
> - 알고리즘 유형 : `트리`
> - 내용
> ```
> “A가 B의 부모이다”라는 조건이 있어서 자식 → 부모로 올라갈 수 있게 단방향으로 연결
> A, B의 가장 가까운 공통 조상을 찾기 위해서
>    - 먼저 A 노드를 탐색하면서 찾을 수 있는 모든 조상을 방문처리 해준다
>    - 그 다음 B 노드를 탐색할때엔 현재 노드가 이미 방문되어 있으면 가장 가까운 공통 조상 발견한 것, 만약 방문하지 않았을 경우에는 그 위의 조상 찾기를 수행해준다
> 알고리즘 분류에 최소 공통 조상이라는 것이 있길래 풀고나서 찾아봤더니 LCA알고리즘을 이용해서 많이 풀더라는~
> ```

<br/>

> ### [백준] 11437 LCA
> - 난이도 : `골드3`
> - 알고리즘 유형 : `LCA`
> - 내용
> ```
> 가장 가까운 공통 조상문제 풀다가 LCA 알고리즘에 대해 알게돼서 연습할 겸 푼 문제
> dfs를 이용해서 먼저 모든 노드의 parent, depth를 찾아 기록해준다
> 두 정점의 공통 조상을 찾기 위해서는
>  1. 깊이를 같게 만들어주기 -> 깊이가 더 큰쪽의 깊이를 줄이고 부모 그 위로 갱신
>  2. 깊이가 같아졌으면 공통 부모 찾기 -> 공통 부모 찾을때까지 위로 올라가면서 부모 갱신
> ```

<br/>

> ### [프로그래머스] 42586 기능개발
> - 난이도 : `레벨2`
> - 알고리즘 유형 : `큐`
> - 내용
> ```
> 며칠간 작업을 해야 배포할 수 있는지 queue에 담고 
> before(전 작업일)을 기준으로 현재 작업일이 더 작거나 같을 경우에는 배포를 같이할 수 있으니 전값에 +1
> 클 경우에는 인덱스 증가해서 새로운 배포일을 기록해줘서 푼 문제
> ```

<br/>

> ### [백준] 1541 잃어버린괄호
> - 난이도 : `실버2`
> - 알고리즘 유형 : `그리디`
> - 내용
> ```
> 최솟값을 만들기 위해서는 뺄셈을 기준으로 생각해야 한다 ⇒ 덧셈을 모두 먼저 더해준뒤 빼줘야 함
> 뺄셈을 기준으로 나눈다음 덧셈 부분을 계산하고 첫번째 숫자가 아닐경우 다 빼주면 된다
> 그리디 연습을 더 많이 해야겠다
> ```
