### PR TITLE
0320 육다빈 5문제

### DIFF
--- a/육다빈/week11_0320/백준_1039_교환.java
+++ b/육다빈/week11_0320/백준_1039_교환.java
@@ -1,0 +1,71 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class G1039_change {
+
+// 문제 푸는 방법을 아직 끝까지 떠올리지 못함...
+  
+//	static class Number implements Comparable<Number>{
+//		int value, idx;
+//		Number(int value, int idx){
+//			this.value = value;
+//			this.idx = idx;
+//		}
+//		
+//		@Override
+//		public int compareTo(Number o) {
+//			if(this.value == o.value) return o.idx-this.idx;
+//			else return o.value-this.value;
+//		}
+//	}
+	
+	static int[] number;
+	
+	static int findMax(int start) { //최고값이 있는 자리수 반환
+		int max = start;
+		for(int i=number.length-1; i>start; i--) {
+			if(number[max] < number[i]) max = i;
+		}
+		return max;
+	}
+	
+	static void swap(int a, int b) { //자리 교환
+		int tmp = number[a];
+		number[a] = number[b];
+		number[b] = tmp;
+	}
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		char[] N = st.nextToken().toCharArray();
+		int K = Integer.parseInt(st.nextToken());
+		
+		number = new int[N.length];
+		for(int i=0; i<N.length; i++) number[i] = N[i]-'0';
+		
+		int k=0;
+		for(int i=0; i<N.length; i++) {
+			int idx_max = findMax(i);
+			if(idx_max==i) continue;
+			
+			swap(i, idx_max);
+
+			if(++k == K) {
+				while(++i<N.length) {
+					sb.append(number[i]);
+				}
+			}
+			System.out.println(Arrays.toString(number));
+		}
+
+		
+		System.out.println((k==K) ? sb : -1);
+	}

--- a/육다빈/week11_0320/백준_1039_교환.java
+++ b/육다빈/week11_0320/백준_1039_교환.java
@@ -9,22 +9,6 @@ import java.util.StringTokenizer;
 
 public class G1039_change {
 
-// 문제 푸는 방법을 아직 끝까지 떠올리지 못함...
-  
-//	static class Number implements Comparable<Number>{
-//		int value, idx;
-//		Number(int value, int idx){
-//			this.value = value;
-//			this.idx = idx;
-//		}
-//		
-//		@Override
-//		public int compareTo(Number o) {
-//			if(this.value == o.value) return o.idx-this.idx;
-//			else return o.value-this.value;
-//		}
-//	}
-	
 	static int[] number;
 	
 	static int findMax(int start) { //최고값이 있는 자리수 반환
@@ -48,24 +32,25 @@ public class G1039_change {
 		char[] N = st.nextToken().toCharArray();
 		int K = Integer.parseInt(st.nextToken());
 		
-		number = new int[N.length];
-		for(int i=0; i<N.length; i++) number[i] = N[i]-'0';
+		int len = N.length;
+		number = new int[len];
+		for(int i=0; i<len; i++) number[i] = N[i]-'0';
 		
 		int k=0;
 		for(int i=0; i<N.length; i++) {
 			int idx_max = findMax(i);
 			if(idx_max==i) continue;
-			
 			swap(i, idx_max);
-
-			if(++k == K) {
-				while(++i<N.length) {
-					sb.append(number[i]);
-				}
-			}
-			System.out.println(Arrays.toString(number));
+			
+			if(++k==K) break;
 		}
-
 		
-		System.out.println((k==K) ? sb : -1);
+		if(k<K && ((len==2 && number[1]==0) || len==1) ) System.out.println(-1);
+		else {
+			while(++k<=K) {
+				swap(len-2, len-1);
+			}
+			for(int n : number) System.out.print(n);
+		}
 	}
+}

--- a/육다빈/week11_0320/백준_11725_트리의부모찾기.java
+++ b/육다빈/week11_0320/백준_11725_트리의부모찾기.java
@@ -1,0 +1,49 @@
+package silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class S11725_findParents {
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		List<Integer>[] childs = new List[N+1];
+		for(int i=1; i<=N; i++) childs[i] = new ArrayList<Integer>();
+		
+		for(int i=0; i<N-1; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			childs[a].add(b);
+			childs[b].add(a);
+		}
+		
+		int[] parent = new int[N+1];
+		Queue<Integer> queue = new LinkedList<Integer>();
+		queue.add(1);
+		while(!queue.isEmpty()) {
+			int size = queue.size();
+			for(int i=0; i<size; i++) {
+				int now = queue.poll();
+				for(int child : childs[now]) {
+					if(parent[child]!=0) continue;
+					parent[child] = now;
+					queue.add(child);
+				}
+			}
+		}
+		
+		StringBuilder sb = new StringBuilder();
+		for(int i=2; i<=N; i++) sb.append(parent[i]+"\n");
+		
+		System.out.println(sb);
+	}
+
+}

--- a/육다빈/week11_0320/백준_14500_테트로미노.java
+++ b/육다빈/week11_0320/백준_14500_테트로미노.java
@@ -1,0 +1,77 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class G14500_tetromino {
+	static int N, M;
+	static int[][] map, visit;
+	static int[] di = {-1, 0, 1, 0};
+	static int[] dj = {0, 1, 0, -1};
+	
+	static int dfs(int i, int j, int cnt, int sum) {
+		if(cnt==4) {
+			return sum;
+		}
+		visit[i][j] = -1;
+		int max = -1;
+		for(int d=0; d<4; d++) {
+			int ni = i + di[d];
+			int nj = j + dj[d];
+			if(ni<0 || ni>=N || nj<0 || nj>=M || visit[ni][nj]!=0) continue;
+			max = Math.max(max, dfs(ni, nj, cnt+1, sum+map[ni][nj]));
+		}
+		visit[i][j] = 0;
+		return max;
+	}
+	
+	static int checkT(int i, int j) {
+		int result=map[i][j], cnt=0;
+		int min = Integer.MAX_VALUE;
+		for(int d=0; d<4; d++) {
+			int ni = i + di[d];
+			int nj = j + dj[d];
+			if(ni<0 || ni>=N || nj<0 || nj>=M) continue;
+			cnt++;
+			result += map[ni][nj];
+			min = Math.min(min, map[ni][nj]);
+		}
+		if(cnt==4) return result-min;
+		else if(cnt==3) return result;
+		else return -1;
+	}
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		
+		map = new int[N][M];
+		for(int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j=0; j<M; j++) map[i][j] = Integer.parseInt(st.nextToken());
+		}
+
+		// 1. 한줄로 연결되는 4종류의 테트로미노 검사
+		int result = -1;
+		visit = new int[N][M];
+		for(int i=0; i<N; i++) {
+			for(int j=0; j<M; j++) {
+				result = Math.max(result, dfs(i, j, 1, map[i][j]));
+			}
+		}
+		
+		// 2. T자형 테트로미노 검사
+		for(int i=0; i<N; i++) {
+			for(int j=0; j<M; j++) {
+				result = Math.max(result, checkT(i, j));
+			}
+		}
+		
+		System.out.println(result);
+	}
+
+}

--- a/육다빈/week11_0320/백준_14621_나만안되는연애.java
+++ b/육다빈/week11_0320/백준_14621_나만안되는연애.java
@@ -1,0 +1,75 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class G14621_noMoreLove {
+	
+	static int[] parent;
+
+	static class Edge implements Comparable<Edge>{
+		int from, to, weight;
+		Edge(int from, int to, int weight){
+			this.from = from;
+			this.to = to;
+			this.weight = weight;
+		}
+		@Override
+		public int compareTo(Edge o) {
+			return this.weight - o.weight;
+		}
+	}
+	
+	static int findParent(int a) {
+		if(parent[a]!=a) parent[a] = findParent(parent[a]);
+		return parent[a];
+	}
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		char[] gender = new char[N+1];
+		parent = new int[N+1];
+		
+		st = new StringTokenizer(br.readLine());
+		for(int i=1; i<=N; i++) {
+			gender[i] = (char) st.nextToken().charAt(0);
+			parent[i] = i;
+		}
+		
+		PriorityQueue<Edge> queue = new PriorityQueue<Edge>();
+		for(int i=0; i<M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int from = Integer.parseInt(st.nextToken()); 
+			int to = Integer.parseInt(st.nextToken()); 
+			int weight = Integer.parseInt(st.nextToken()); 
+			
+			if(gender[from] != gender[to]) queue.add(new Edge(from, to, weight));
+		}
+		
+		
+		int cnt=0, sum=0;
+		boolean[] visit = new boolean[N+1];
+		
+		while(cnt<N-1 && !queue.isEmpty()) {
+			Edge now = queue.poll();
+			int parent_from = findParent(now.from);
+			int parent_to = findParent(now.to);
+			if(parent_from == parent_to) continue;
+			
+			parent[parent_to] = parent_from;
+			sum += now.weight;
+			cnt++;
+		}
+		System.out.println((cnt==N-1) ? sum : -1);
+	}
+
+}

--- a/육다빈/week11_0320/백준_2504_괄호의값.java
+++ b/육다빈/week11_0320/백준_2504_괄호의값.java
@@ -1,0 +1,50 @@
+package silver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class S2504_bracketsValue {
+	
+	static int calc(char[] str) {
+		Stack<Integer> stack = new Stack<Integer>();
+		
+		for(char c : str) {
+			
+			if(c=='(' || c=='[') { // '('=-2, '['=-3
+				stack.add((c=='(') ? -2 : -3);
+				
+			}else {
+				if(stack.isEmpty()) return 0;
+				int top = stack.pop();
+				if((top==-2 && c==')') || (top==-3 && c==']')) {
+					int nextTop = 0;
+					if(!stack.isEmpty() && stack.peek()>0) nextTop = stack.pop(); // 앞에 더할 수가 있는 경우
+					stack.add(nextTop + (-1)*top);
+					
+				}else if(top>0){
+					if(stack.isEmpty() || // 이번 괄호의 짝이 없거나, 알맞은 괄호짝이 아닐 경우
+							((c==')')&&(stack.peek()!=-2)) || ((c==']')&&(stack.peek()!=-3))) return 0;
+					stack.pop();
+					int res = top*((c==')') ? 2 : 3); // 앞 계산결과에 곱셈
+					if(!stack.isEmpty() && stack.peek()>0) res += stack.pop();
+					stack.add(res);
+					
+				}else{
+					return 0;
+				}
+			}
+		}
+		
+		if(stack.size()>1 || stack.peek()<0) return 0;
+		else return stack.pop();
+	}
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		System.out.println(calc(br.readLine().toCharArray()));
+	}
+
+}


### PR DESCRIPTION
> ### [백준] 14621 나만 안되는 연애  
> - 난이도 : `골드 3`
> - 알고리즘 유형 : `union-find`, `Kruskal`, `MST`
> - 내용
> ```
> 간선들을 우선순위 큐에 넣어 가중치가 낮은 순으로 사이클이 되지 않는 선에서 꺼내어 트리를 만든다.
> n개의 정점을 연결하는 `최소 간선 수(n-1)` 만큼 꺼내면 끝.
> 꺼낸 간선을 연결하면 사이클이 생기는지 확인하는 과정에서 `union-find`를 사용하였는데,
> 간선을 연결해 부모를 통일하는 과정중에 변경할 트리의 루트노드의 부모값을 변경하지 않고
> 하위노드의 부모값을 변경하는 실수가 있었다.
> ```

<br/>

> ### [백준] 1039 교환 (F)
> - 난이도 : `골드 3`
> - 알고리즘 유형 : ``
> - 내용
> ```
> 너무 단순하게 풀었나 시작하자마자 틀림..
> ```

<br/>

> ### [백준] 14500 테트로미노  
> - 난이도 : `골드 4`
> - 알고리즘 유형 : `DFS`
> - 내용
> ```
> 5가지 유형의 테트로미노 중 4종류는 한줄로 연결할 수 있는 모양이라 각 자리별로 dfs로 탐색한다.
> 그러나 나머지 한종류(T자형)은 DFS로는 탐색할 수 없는 모양이라, 그냥 사방탐색으로 따로 구했다.
> ```

<br/>

> ### [백준] 2504 괄호의 값  
> - 난이도 : `난이도`
> - 알고리즘 유형 : `자료구조`, `스택`
> - 내용
> ```
> 여는괄호와 중간에 계산된 결과값을 스택에 넣고, 
> 닫는 괄호를 만날때마다 가장 상위의 결과값과 여는 괄호를 연산하고 다시 넣는 방식으로 진행
> ```

<br/>

> ### [백준] 11725 트리의 부모 찾기  
> - 난이도 : `실버 2`
> - 알고리즘 유형 : `BFS`
> - 내용
> ```
> 각 노드의 인접노드들을 List에 저장하고, 루트노드부터 BFS나 DFS로 내려가면서 바로 상위의 노드 값을 저장해주면 된다.
> ```
