### PR TITLE
0327 이화연 5문제

### DIFF
--- a/이화연/11주차/BOJ_Gold3_1039_교환.java
+++ b/이화연/11주차/BOJ_Gold3_1039_교환.java
@@ -1,7 +1,8 @@
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.PriorityQueue;
+import java.util.LinkedList;
+import java.util.Queue;
 import java.util.StringTokenizer;
 
 public class BOJ_Gold3_1039_교환 {
@@ -11,78 +12,53 @@ public class BOJ_Gold3_1039_교환 {
 		StringTokenizer st = new StringTokenizer(br.readLine());
 		String N = st.nextToken();// 숫자
 		int K = Integer.parseInt(st.nextToken());// 연산 수
-		int[] arr = new int[N.length()];
+		boolean[][] visited = new boolean[K + 1][1000001];
 
-		for (int i = 0; i < arr.length; i++) {
-			arr[i] = Integer.parseInt(N.charAt(i) + "");
-		}
+		Queue<String> queue = new LinkedList<>();
+		queue.add(N);
 
-		PriorityQueue<Number> max = new PriorityQueue<>();
-		for (int i = 0; i < arr.length; i++) {
-			max.add(new Number(arr[i], i));
-		}
+		while (!queue.isEmpty() && K > 0) {
+			int size = queue.size();
+			for (int s = 0; s < size; s++) {
+				String now = queue.poll();
 
-		boolean flag = false; // 0으로 시작하는지 확인할 변수
-		if (arr.length < 2) { // 길이가 1이면 바꿀게 없으니 안됨
-			flag = true;
-		}
+				for (int i = 0; i < N.length() - 1; i++) {
+					for (int j = i + 1; j < N.length(); j++) {
+						int next = swap(now, i, j);
+						// 맨 앞자리가 0이 아니고 현재 수가 지금 turn에서 방문한 적이 없을때
+						if (next != -1 && !visited[K][next]) {
+							queue.add(String.valueOf(next));
+							visited[K][next] = true;
+						}
+					}
+				}
 
-		int idx = 0;
-		while (!max.isEmpty() && !flag) {
-			Number now = max.poll();
-			int num = arr[idx];
-
-			// max 큐에서 꺼낸 값이 현재 값보다 크고
-			// max 큐에서 꺼낸 값의 인덱스가 현재 인덱스보다 클때
-			if (num < now.value && idx < now.idx && idx < arr.length) {
-				arr[now.idx] = num; // 위치를 바꿔준다
-				arr[idx++] = now.value;
-				K--; // 연산 횟수 감소
-			}
-			if (arr[0] == 0) { // 바꿨는데 맨 앞자리가 0인경우 안됨
-				flag = true;
-				break;
-			}
-
-			if (K == 0) {
-				break;
-			}
-		}
-
-		idx = arr.length - 1;
-		while (K > 0 && !flag) { // 연산횟수가 남아있다면 맨 뒤 2자리를 계속 연산해준다
-			int temp = arr[idx];
-			arr[idx] = arr[idx - 1];
-			arr[idx - 1] = temp;
-			if (arr[0] == 0) { // 맨 앞자리가 0인 경우 안됨
-				flag = true;
-				break;
 			}
 			K--;
 		}
-		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < arr.length; i++) {
-			sb.append(arr[i]);
+
+		int max = -1;
+		for (String s : queue) { // 큐에 있는 것 중 최대값 뽑기
+			max = Math.max(max, Integer.parseInt(s));
 		}
-		System.out.println(flag ? -1 : sb.toString());
+		System.out.println(max);
 
 	}
 
-	static class Number implements Comparable<Number> {
-		int value, idx;
+	static int swap(String now, int i, int j) {
+		char[] arr = now.toCharArray();
+		char temp = arr[i];
+		arr[i] = arr[j];
+		arr[j] = temp;
 
-		public Number(int value, int idx) {
-			super();
-			this.value = value;
-			this.idx = idx;
+		if (arr[0] == '0') { // 맨 앞이 0이면 안됨
+			return -1;
 		}
 
-		@Override
-		public int compareTo(Number o) {
-			if (this.value == o.value) {
-				return o.idx - this.idx;
-			}
-			return o.value - this.value;
+		String newStr = "";
+		for (char c : arr) {
+			newStr += c + "";
 		}
+		return Integer.parseInt(newStr);
 	}
 }

--- a/이화연/12주차/BOJ_Gold3_25307_시루의백화점구경.java
+++ b/이화연/12주차/BOJ_Gold3_25307_시루의백화점구경.java
@@ -1,0 +1,109 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_Gold3_25307_시루의백화점구경 {
+	static int N, M, K, map[][];
+	static Point siru;
+	static Queue<Point> mannequin;
+	static int di[] = { -1, 1, 0, 0 };
+	static int dj[] = { 0, 0, -1, 1 };
+	static boolean[][] mVisited;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken()); // 행
+		M = Integer.parseInt(st.nextToken()); // 열
+		K = Integer.parseInt(st.nextToken()); // 마네킹과 떨어져야 하는 거리
+		map = new int[N][M];
+		mannequin = new LinkedList<>(); // 마네킹 위치 담을 큐
+		mVisited = new boolean[N][M]; // 마네킹 방문처리할 배열
+
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < M; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+				if (map[i][j] == 3) { // 마네킹 위치
+					mannequin.add(new Point(i, j, 0));
+					mVisited[i][j] = true; // 마네킹이 위치한 곳 방문처리
+				} else if (map[i][j] == 4) {
+					siru = new Point(i, j, 0);
+				}
+			}
+		}
+
+		// 마네킹 위치에서 K이하인 곳을 찾아 못가게 만들기
+		findMannequin();
+		map[siru.i][siru.j] = 4; // 시루가 위치했던 곳은 다시 4로 바꾸기
+
+		// 시루 위치에서 의자 찾기
+		System.out.println(bfs());
+	}
+
+	static int bfs() {
+		Queue<Point> queue = new LinkedList<>();
+		queue.add(siru);
+		boolean[][] visited = new boolean[N][M];
+		visited[siru.i][siru.j] = true;
+
+		while (!queue.isEmpty()) {
+			Point now = queue.poll();
+
+			if (map[now.i][now.j] == 2) {
+				return now.cnt;
+			}
+
+			for (int d = 0; d < 4; d++) {
+				int nexti = now.i + di[d];
+				int nextj = now.j + dj[d];
+				// 범위 벗어나거나 이미 방문한 곳, 기둥이나 마네킹인 곳은 안됨
+				if (nexti < 0 || nexti >= N || nextj < 0 || nextj >= M || visited[nexti][nextj]
+						|| map[nexti][nextj] == 1 || map[nexti][nextj] == 3)
+					continue;
+				queue.add(new Point(nexti, nextj, now.cnt + 1));
+				visited[nexti][nextj] = true;
+			}
+		}
+
+		return -1;
+	}
+
+	static void findMannequin() {
+		while (!mannequin.isEmpty()) {
+			Point now = mannequin.poll();
+
+			for (int d = 0; d < 4; d++) {
+				int nexti = now.i + di[d];
+				int nextj = now.j + dj[d];
+
+				// 범위 벗어나거나, 이미 방문한 곳이면 패스
+				// 의자가 위치한 곳이어도 마네킹이 갈 수 있는 거리면 결국 못감
+				if (nexti < 0 || nexti >= N || nextj < 0 || nextj >= M || mVisited[nexti][nextj])
+					continue;
+
+				// 현재 위치에서 +1한 값이 K 이하이면 마네킹이 위치할 수 있는곳
+				if (now.cnt + 1 <= K) {
+					mannequin.add(new Point(nexti, nextj, now.cnt + 1));
+					map[nexti][nextj] = 3; // 마네킹 위치한 곳으로 바꾸기
+					mVisited[nexti][nextj] = true;
+				}
+			}
+		}
+	}
+
+	static class Point {
+		int i, j, cnt;
+
+		public Point(int i, int j, int cnt) {
+			super();
+			this.i = i;
+			this.j = j;
+			this.cnt = cnt;
+		}
+	}
+
+}

--- a/이화연/12주차/BOJ_Silver1_1389_케빈베이컨의6단계법칙.java
+++ b/이화연/12주차/BOJ_Silver1_1389_케빈베이컨의6단계법칙.java
@@ -1,0 +1,70 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_Silver1_1389_케빈베이컨의6단계법칙 {
+	static int N, M;
+	static ArrayList<Integer>[] list;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		list = new ArrayList[N + 1];
+
+		for (int i = 1; i <= N; i++) {
+			list[i] = new ArrayList<>();
+		}
+
+		for (int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			list[a].add(b);
+			list[b].add(a);
+		}
+
+		int ans = 0;
+		int min = Integer.MAX_VALUE;
+		for (int i = 1; i <= N; i++) {
+			int result = findKevinBacon(i);
+			if (min > result) {
+				min = result;
+				ans = i;
+			}
+		}
+		System.out.println(ans);
+	}
+
+	static int findKevinBacon(int num) {
+		Queue<int[]> queue = new LinkedList<>();
+		boolean[] visited = new boolean[N + 1];
+		queue.add(new int[] { num, 0 });
+		visited[num] = true;
+		int[] sum = new int[N + 1];
+		while (!queue.isEmpty()) {
+			int[] now = queue.poll();
+
+			for (Integer next : list[now[0]]) {
+				if (!visited[next]) {
+					queue.add(new int[] { next, now[1] + 1 });
+					visited[next] = true;
+					sum[next] = now[1] + 1;
+				}
+			}
+		}
+
+		int ans = 0;
+		for (int i = 1; i <= N; i++) {
+			if (num != i) {
+				ans += sum[i];
+			}
+		}
+		return ans;
+	}
+}

--- a/이화연/12주차/BOJ_Silver1_1446_지름길.java
+++ b/이화연/12주차/BOJ_Silver1_1446_지름길.java
@@ -1,0 +1,61 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_Silver1_1446_지름길 {
+	static int N, D, dist[];
+	static ArrayList<Road>[] roads;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		D = Integer.parseInt(st.nextToken());
+		dist = new int[D + 1]; // 거리 최솟값 저장할 배열
+		roads = new ArrayList[10001]; // 지름길 저장할 배열
+
+		for (int i = 1; i < 10001; i++) {
+			roads[i] = new ArrayList<>();
+		}
+
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			int s = Integer.parseInt(st.nextToken());
+			int e = Integer.parseInt(st.nextToken());
+			int d = Integer.parseInt(st.nextToken());
+			if (e - s > d) { // 지름길이 더 유리할때만
+				roads[e].add(new Road(s, d));
+			}
+		}
+
+		Arrays.fill(dist, Integer.MAX_VALUE);
+		dist[0] = 0;
+		for (int i = 1; i <= D; i++) {
+			if (roads[i].size() > 0) { // 도착 지점에 지름길이 존재함
+				for (Road r : roads[i]) {
+					if (dist[r.start] + r.d > dist[i]) // 이미 작으면 갱신하지마
+						continue;
+					// 바로이전 도로에서 +1 한 값과 지름길로 지나온 값중 최소로 갱신
+					dist[i] = Math.min(dist[i - 1] + 1, dist[r.start] + r.d);
+				}
+			} else { // 지름길 없으면 바로 이전 도로 +1
+				dist[i] = dist[i - 1] + 1;
+			}
+		}
+		System.out.println(dist[D]);
+
+	}
+
+	static class Road {
+		int start, d;
+
+		public Road(int start, int d) {
+			super();
+			this.start = start;
+			this.d = d;
+		}
+	}
+}

--- a/이화연/12주차/BOJ_Silver2_16953_AtoB.java
+++ b/이화연/12주차/BOJ_Silver2_16953_AtoB.java
@@ -1,0 +1,33 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_Silver2_16953_AtoB {
+	static long A, B, min;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		A = Long.parseLong(st.nextToken());
+		B = Long.parseLong(st.nextToken());
+		min = Long.MAX_VALUE;
+
+		dfs(A, 0);
+		System.out.println(min == Long.MAX_VALUE ? -1 : min);
+	}
+
+	static void dfs(long num, long cnt) {
+		if (num > B || cnt + 1 > min) {
+			return;
+		}
+
+		if (num == B) {
+			min = Math.min(min, cnt + 1);
+		}
+
+		dfs(num * 2, cnt + 1);
+		String s = String.valueOf(num) + "1";
+		dfs(Long.parseLong(s.trim()), cnt + 1);
+	}
+}


### PR DESCRIPTION
> ### [백준] 25307 시루의백화점구경
> - 난이도 : `골드3`
> - 알고리즘 유형 : `bfs`
> - 내용
> ```
> 입력값 받고 -> 마네킹 위치에서 K 이하인 곳 찾아 못가게 만들고 -> 시루 위치에서 의자 찾기 순으로 코드를 작성했다.
> 주의할 점은 마네킹 위치에서 K이하인 곳 찾을때 시루나 의자, 기둥 위치한 곳 모두 예외처리 없이 마네킹으로 바꿔주는 작업을 수행해야한다.
> 4 4 2
> 2 0 0 0
> 0 4 0 0
> 0 3 0 0
> 0 0 0 0
> 위의 예시에서 (0,1)도 마네킹이 갈 수 있는 위치인데 시루가 위치한 (1,1)에 막혀 갈 수 없는 상황이 발생하면 안되기 때문
> ```

<br/>

> ### [백준] 12784 인하니카공화국 (F)
> - 난이도 : `골드3`
> - 알고리즘 유형 : `DP`
> - 내용
> ```
> 문제는 이해했는데.. 점화식을 어떻게 세워야할지 감도 안온다.. DP 넘 어려워..
> ```

<br/>

> ### [백준] 16953 A->B
> - 난이도 : `실버2`
> - 알고리즘 유형 : `DFS`
> - 내용
> ```
> 간단한 DFS문제지만 주의해야할 점은 입력의 범위값
> 10^9까지 입력이 들어오고 곱셈 연산을 수행하기 때문에 모든 숫자들을 long으로 선언해줘야함
> ```

<br/>

> ### [백준] 1389 케빈 베이컨의 6단계 법칙
> - 난이도 : `실버1`
> - 알고리즘 유형 : `BFS`
> - 내용
> ```
> 정점 1~N까지 bfs를 이용해서 각 정점에 몇번 이동해야 가는지를 기록해준 다음 가장 최솟값의 인덱스를 찾아줬다.
> ```

<br/>

> ### [백준] 1446 지름길
> - 난이도 : `실버1`
> - 알고리즘 유형 : `다익스트라`
> - 내용
> ```
> 도착지점-시작지점 보다 지름길이 더 유리할때만 roads 배열에 지름길 정보를 저장해준다.
> 도로 1부터 D까지 현재 도로에 지름길이 존재한다면 "전도로+1" 값과 "지름길" 값을 비교해서 더 작은 것으로 세팅
> ```
