### PR TITLE
0327 육다빈 5문제

### DIFF
--- a/육다빈/week10_0313/백준_27210_신을모시는사당.java
+++ b/육다빈/week10_0313/백준_27210_신을모시는사당.java
@@ -3,39 +3,48 @@ package gold;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 import java.util.StringTokenizer;
 
 public class G27210_shrineToDeity {
+	static int N;
+	static int[] arr;
+	
+	// countMax : plus인 방향이 더 많이 포함된 경우 중 최댓값 계산
+	static int countMax(int plus) { 
+		int sum = 0; //return할 최댓값
+		
+		int tmp=0;
+		for(int i=0; i<N; i++) {
+			if(arr[i]==plus) { // plus방향이면 역방향이 나오기 전까지 계속 누적
+				tmp += 1;
+			}else { // 역방향이 나온 경우,
+				sum = Math.max(sum, tmp); // 앞으로 계속 값이 차감될 것이니, 현재값과 기존 누적값 중 최댓값 저장
+				while(i<N && arr[i]!=plus) { // 역방향이 끝날때까지 차감 진행
+					tmp -= 1;
+					i++;
+				}
+				i--;
+				if(tmp<0) tmp=0; //역방향을 모두 돌았을 때 누적값이 음수면, 이 값은 다음 값에 누적해서 더할 필요가 없다.
+			}
+		}
+
+		if(arr[N-1] == plus) sum = Math.max(sum, tmp); // 배열의 마지막이 순방향만 있어서, 마지막 누적값이 반영 안된경우 처리
+		
+		return sum;
+	}
 	
 	public static void main(String[] args) throws IOException{
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-		int N = Integer.parseInt(br.readLine());
 		
-		int[] stones = new int[N];
+		N = Integer.parseInt(br.readLine());
+		arr = new int[N];
+		
 		StringTokenizer st = new StringTokenizer(br.readLine());
-		int total_l=0, total_r=0;
-		for(int i=0; i<N; i++) {
-			stones[i] = Integer.parseInt(st.nextToken());
-			if(stones[i]==1) total_l++;
-			else total_r++;
-		}
+		for(int i=0; i<N; i++) arr[i] = Integer.parseInt(st.nextToken());
 		
-		int result = Math.abs(total_l-total_r);
-		int sum = result;
-		for(int i=0; i<N; i++) {
-			sum -= stones[i];
-			
-			if(N-i <= result) break;
-			int left=0, right=0;
-			for(int j=i; j<N; j++) {
-				if(stones[j]==1) left++;
-				else right++;
-				int now = Math.abs(left-right);
-				result = Math.max(result, now);
-				if(now + N-1-j <= result) break;
-			}
-		}
-		System.out.println(result);
+		System.out.println(Math.max(countMax(1), countMax(2))); // 오른쪽과 왼쪽을 정방향으로 생각했을 때 최댓값 중 큰 값 출력
+		
 	}
 
 }

--- a/육다빈/week11_0320/백준_1039_교환.java
+++ b/육다빈/week11_0320/백준_1039_교환.java
@@ -4,53 +4,59 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Arrays;
-import java.util.PriorityQueue;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
 import java.util.StringTokenizer;
 
 public class G1039_change {
 
-	static int[] number;
-	
-	static int findMax(int start) { //최고값이 있는 자리수 반환
-		int max = start;
-		for(int i=number.length-1; i>start; i--) {
-			if(number[max] < number[i]) max = i;
-		}
-		return max;
-	}
-	
-	static void swap(int a, int b) { //자리 교환
-		int tmp = number[a];
-		number[a] = number[b];
-		number[b] = tmp;
+	static int change(String number, int i, int j) {
+		char a = number.charAt(i);
+		char b = number.charAt(j);
+		String result = number.substring(0, i) + b + number.substring(i+1, j) + a + number.substring(j+1);
+		
+		if(result.charAt(0)=='0') return -1;
+		else return Integer.parseInt(result);
 	}
 	
 	public static void main(String[] args) throws IOException{
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 		StringTokenizer st = new StringTokenizer(br.readLine());
 		
-		char[] N = st.nextToken().toCharArray();
+		int start = Integer.parseInt(st.nextToken());
 		int K = Integer.parseInt(st.nextToken());
 		
-		int len = N.length;
-		number = new int[len];
-		for(int i=0; i<len; i++) number[i] = N[i]-'0';
+		Queue<Integer> queue = new LinkedList<Integer>();
+		queue.add(start);
 		
-		int k=0;
-		for(int i=0; i<N.length; i++) {
-			int idx_max = findMax(i);
-			if(idx_max==i) continue;
-			swap(i, idx_max);
-			
-			if(++k==K) break;
+		int cnt=0, len = (start+"").length();
+		while(!queue.isEmpty() && ++cnt<=K) {
+			int size = queue.size();
+			boolean[] visit = new boolean[(int) Math.pow(10, len)];
+
+			for(int s=0; s<size; s++) {
+				int now = queue.poll();
+				
+				for(int i=0; i<len; i++) {
+					for(int j=i+1; j<len; j++) {
+						int chg = change(now+"", i, j);
+
+						if(chg<0 || visit[chg]) continue;
+					
+						visit[chg] = true;
+						queue.add(chg);
+					}
+				}
+			}
 		}
 		
-		if(k<K && ((len==2 && number[1]==0) || len==1) ) System.out.println(-1);
+		if(queue.isEmpty()) System.out.println(-1);
 		else {
-			while(++k<=K) {
-				swap(len-2, len-1);
-			}
-			for(int n : number) System.out.print(n);
+			Object[] tmp = queue.toArray();
+			Arrays.sort(tmp, Collections.reverseOrder());
+			System.out.println(tmp[0]);
 		}
 	}
 }

--- a/육다빈/week12_0327/백준_12784_인하니카공화국.java
+++ b/육다빈/week12_0327/백준_12784_인하니카공화국.java
@@ -1,0 +1,67 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class G12784_InhanikaRepublic {
+	static int N, M;
+	static List<Node>[] edges;
+	static boolean[] visit;
+	
+	static class Node{
+		int to, weight;
+		Node(int to, int weight){
+			this.to = to;
+			this.weight = weight;
+		}
+	}
+	
+	static int dfs(int parent, int weight) {
+		int sum = 0;
+		
+		for(Node node : edges[parent]) {
+			if(visit[node.to]) continue;
+			visit[node.to] = true;
+			sum += dfs(node.to, node.weight); // 자식노드의 하위에 있는 가중치들의 최소 합
+		}
+		
+		if(weight==0) return sum; // parent가 루트노드인 경우
+		else if(sum==0) return weight; // parent가 리프노드인 경우
+		else return Math.min(sum, weight);
+	}
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		int T = Integer.parseInt(br.readLine());
+		
+		for(int t=0; t<T; t++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			N = Integer.parseInt(st.nextToken());
+			M = Integer.parseInt(st.nextToken());
+			
+			edges = new List[N+1];
+			for(int i=1; i<=N; i++) edges[i] = new ArrayList<Node>();
+			
+			for(int i=0; i<M; i++) {
+				st = new StringTokenizer(br.readLine());
+				int from = Integer.parseInt(st.nextToken());
+				int to = Integer.parseInt(st.nextToken());
+				int weight = Integer.parseInt(st.nextToken());
+				
+				edges[from].add(new Node(to, weight));
+				edges[to].add(new Node(from, weight));
+			}
+			
+			visit = new boolean[N+1];
+			visit[1] = true;
+			
+			System.out.println(dfs(1, 0));
+		}
+	}
+
+}

--- a/육다빈/week12_0327/백준_25307_시루의백화점구경.java
+++ b/육다빈/week12_0327/백준_25307_시루의백화점구경.java
@@ -1,0 +1,102 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class G25307_sirusDepartmentstoreTour {
+	static int N, M, K;
+	static int[][] map;
+	static int[] di = {-1, 0, 1, 0};
+	static int[] dj = {0, 1, 0, -1};
+	
+	static class Point{
+		int i, j;
+		Point(int i, int j){
+			this.i = i;
+			this.j = j;
+		}
+	}
+	
+	// replaceMannequin : 마네킹과의 거리가 K이하긴 구간들의 값을 3으로 변환
+	static void replaceMannequin(Queue<Point> queue) {
+		int cnt=0;
+		while(!queue.isEmpty() && ++cnt<=K) {
+			int size = queue.size();
+		
+			for(int s=0; s<size; s++) {
+				Point now = queue.poll();
+			
+				for(int d=0; d<4; d++) {
+					int ni = now.i + di[d];
+					int nj = now.j + dj[d];
+					
+					if(ni<0 || ni>=N || nj<0 || nj>=M || map[ni][nj]==3) continue;
+					map[ni][nj] = 3;
+					queue.add(new Point(ni, nj));
+				}
+			}
+		} 
+	}
+	
+	// findChair : 시루의 위치에서부터 가장 최단거리의 의자 찾기
+	static int findChair(Point siru) {
+		Queue<Point> queue = new LinkedList<Point>();
+		queue.add(siru);
+		
+		int depth=1; // 시루가 움직인 횟수
+		while(!queue.isEmpty()) {
+			int size = queue.size();
+			
+			for(int s=0; s<size; s++) {
+				Point now = queue.poll();
+			
+				for(int d=0; d<4; d++) {
+					int ni = now.i + di[d];
+					int nj = now.j + dj[d];
+				
+					if(ni<0 || ni>=N || nj<0 || nj>=M || 
+							map[ni][nj]==1 || map[ni][nj]==3 || map[ni][nj]==4) continue;
+					
+					if(map[ni][nj]==2) return depth; // 의자 발견
+					map[ni][nj] = 4; // 시루가 방문한 구간은 4로 visit처리
+					queue.add(new Point(ni, nj));
+				}
+			}
+			depth++;
+		}
+		return -1;
+	}
+	
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		
+		map = new int[N][M];
+		Queue<Point> mannequin = new LinkedList<Point>();
+		Point siru = null;
+		
+		for(int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			
+			for(int j=0; j<M; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+				
+				if(map[i][j]==3) mannequin.add(new Point(i, j));
+				else if(map[i][j]==4) siru = new Point(i, j);
+			}
+		}
+		
+		replaceMannequin(mannequin);
+		
+		System.out.println(findChair(siru));
+	}
+
+}

--- a/육다빈/week12_0327/프로그래머스_42628_이중우선순위큐.java
+++ b/육다빈/week12_0327/프로그래머스_42628_이중우선순위큐.java
@@ -1,0 +1,76 @@
+import java.util.*;
+
+class Solution {
+    
+    static class Number implements Comparable<Number>{
+        int idx, value;
+        Number(int idx, int value){
+            this.idx = idx;
+            this.value = value;
+        }
+        @Override
+        public int compareTo(Number o){
+            return this.value - o.value;
+        }
+    }
+    
+    public int[] solution(String[] operations) {
+        
+        PriorityQueue<Number> minQueue = new PriorityQueue<Number>();
+        PriorityQueue<Number> maxQueue = new PriorityQueue<Number>(Collections.reverseOrder());
+        
+        int idx = 0;
+        boolean[] deleted = new boolean[operations.length];
+        
+        for(String oper : operations){
+            StringTokenizer st = new StringTokenizer(oper);
+            
+            if(st.nextToken().charAt(0)=='I'){ //삽입 연산
+                int num = Integer.parseInt(st.nextToken());
+                minQueue.add(new Number(idx, num));
+                maxQueue.add(new Number(idx++, num));
+                
+            }else{ //삭제 연산
+                if(st.nextToken().charAt(0)=='-'){ // 최솟값 삭제
+                    while(!minQueue.isEmpty()){
+                        Number now = minQueue.poll();
+                        if(!deleted[now.idx]) {
+                            deleted[now.idx] = true;
+                            break;
+                        }
+                    }
+                }else{ // 최댓값 삭제
+                    while(!maxQueue.isEmpty()){
+                        Number now = maxQueue.poll();
+                        if(!deleted[now.idx]) {
+                            deleted[now.idx] = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        
+        int[] answer = new int[2];
+        
+        // 최댓값 출력
+        while(!maxQueue.isEmpty()){
+            Number now = maxQueue.poll();
+            if(!deleted[now.idx]) {
+                answer[0] = now.value;
+                break;
+            }
+        }
+        
+        // 최솟값 출력
+        while(!minQueue.isEmpty()){
+            Number now = minQueue.poll();
+            if(!deleted[now.idx]) {
+                answer[1] = now.value;
+                break;
+            }
+        }
+        
+        return answer;
+    }
+}

--- a/육다빈/week12_0327/프로그래머스_43162_네트워크.java
+++ b/육다빈/week12_0327/프로그래머스_43162_네트워크.java
@@ -1,0 +1,29 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int n, int[][] computers) {
+        int answer = 0;
+        boolean[] visit = new boolean[n];
+
+        for(int i=0; i<n; i++){
+            if(visit[i]) continue;
+            
+            answer++;
+            visit[i] = true;
+            
+            Queue<Integer> queue = new LinkedList<Integer>();
+            queue.add(i);
+            
+            while(!queue.isEmpty()){
+                int now = queue.poll();
+                for(int j=0; j<n; j++){
+                    if(!visit[j] && computers[now][j]==1) {
+                        visit[j] = true;
+                        queue.add(j);
+                    } 
+                }
+            }
+        }
+        return answer;
+    }
+}

--- a/육다빈/week12_0327/프로그래머스_77885_2개이하로다른비트.java
+++ b/육다빈/week12_0327/프로그래머스_77885_2개이하로다른비트.java
@@ -1,0 +1,22 @@
+import java.util.*;
+
+class Solution {
+    public long[] solution(long[] numbers) {
+        int N = numbers.length;
+        long[] answer = new long[N];
+        
+        for(int i=0; i<N; i++){
+            if(numbers[i]%2==0) {
+                answer[i] = numbers[i]+1;
+            }else{
+                long bit=1;
+                while((numbers[i] & bit) > 0){
+                    bit *= 2;
+                }
+                answer[i] = numbers[i] + bit/2; //(+ bit - bit/2)
+            }
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
> ### [백준] 20307 시루의 백화점 구경  
> - 난이도 : `골드 3`
> - 알고리즘 유형 : `BFS`
> - 내용
> ```
> 마네킹과 인접한 구간들을 표시하고, 시루의 위치에서부터 거리를 1씩 늘려가며 의자가 나타날 때까지
> 탐색하여 풀었다. BFS로 쉽게 풀리는 문제이지만, 방문처리를 잘못하면 시간초과가 나거나 틀리던 문제.
> ```

<br/>

> ### [백준] 12784 인하니카 공화국  
> - 난이도 : `골드 3`
> - 알고리즘 유형 : `DFS`
> - 내용
> ```
> 하위 노드들의 가중치들의 최소합과 상위노드에 연결된 단일간선의 가중치를 비교해서,
> 더 작은 수를 반환하는 dfs를 구현해서 해결.
> ```

<br/>

> ### [프로그래머스] 77885 2개 이하로 다른 비트  
> - 난이도 : `Lv 2`
> - 알고리즘 유형 : `비트마스킹`
> - 내용
> ```
> 문제를 읽자마자 비트마스킹 문제인걸 알았지만, 비트연산자는 자주 안썼다보니 조금 헤멨다.
> 주어진 숫자의 홀짝여부에 따라 제일 작은 수를 찾는 방법이 달라진다는
> 패턴만 찾으면 빠르게 풀 수 있는 문제.
> ```

<br/>

> ### [프로그래머스] 42628 이중우선순위큐  
> - 난이도 : `Lv 3`
> - 알고리즘 유형 : `자료구조`, `우선순위 큐`
> - 내용
> ```
> 큐에 삽입한 숫자를 크기 순으로 정렬하여 최댓값과 최솟값을 꺼낼 수 있도록 구현하면 되는 문제.
> 자동정렬되는 Deque처럼 쓴다고 생각하고, 정렬 기준을 다르게 한 두가지 큐를 사용해서 풀었다.
> ```

<br/>

> ### [프로그래머스] 43162 네트워크
> - 난이도 : `Lv 3`
> - 알고리즘 유형 : `BFS`
> - 내용
> ```
> 주어진 노드들이 연결된 네트워크 집합의 개수를 세는 union-find 문제인데, 
> BFS나 DFS로도 간단하게 풀릴 수 있을거 같아서 BFS로 풀었다.
> 간선 정보까지 인접배열로 주어져있어서, 입력값을 어떻게 저장할 지 고려할 필요가 없어 더욱 쉬웠던 문제.
> ```