### PR TITLE
0502 한윤석 문제

### DIFF
--- a/한윤석/5월 1주차/백준 20164 홀수 홀릭 호석.java
+++ b/한윤석/5월 1주차/백준 20164 홀수 홀릭 호석.java
@@ -1,0 +1,54 @@
+public class B20168_골목대장호석_기능성 {
+
+	static int ans [] = {Integer.MAX_VALUE, 0}; //[최소, 최대]
+	
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		String s = sc.next();
+		
+		recursion(s, 0);
+		
+		System.out.println(ans[0] + " " + ans[1]);
+	}
+	
+  // s : 현재 문자열, cnt : 누적 홀수 개수
+	static void recursion(String s, int cnt) {
+		int len = s.length();
+		int [] si = new int [len];
+		
+		for(int i=0; i<len; i++) si[i] = s.charAt(i) - '0';
+		
+		int oddCnt = getOddCnt(si); // s에 있는 홀수 수
+		
+		switch(len) {
+			case 1: //길이 1
+				ans[0] = Math.min(ans[0], cnt+oddCnt);
+				ans[1] = Math.max(ans[1], cnt+oddCnt);
+				break;
+			case 2: //길이 2
+				int a1 = s.charAt(0) - '0';
+				int a2 = s.charAt(1) - '0';
+				oddCnt = getOddCnt(new int [] {a1, a2});
+				recursion(Integer.toString(a1+a2), cnt+oddCnt);
+				break;
+			default: //길이 3이상
+        // 문자열을 자를 포인트 2군데를 픽함
+				for(int i=1; i<len-1; i++) {
+					for(int j=i+1; j<len; j++) {
+						int n1 = Integer.parseInt(s.substring(0, i));
+						int n2 = Integer.parseInt(s.substring(i, j));
+						int n3 = Integer.parseInt(s.substring(j));
+						recursion(Integer.toString(n1 + n2 + n3), cnt + oddCnt);
+					}
+				}
+				break;
+		}
+	}
+	
+  // arr 배열 내의 홀수 개수 리턴
+	static int getOddCnt(int [] arr) {
+		int oddCnt = 0;
+		for(int i=0; i<arr.length; i++) if(arr[i] % 2 != 0) oddCnt++;
+		return oddCnt;
+	}
+}

--- a/한윤석/5월 1주차/백준 20168 골목 대장 호석.java
+++ b/한윤석/5월 1주차/백준 20168 골목 대장 호석.java
@@ -1,0 +1,61 @@
+public class B20168_골목대장호석 {
+	
+	static int N,M,A,B,C; // 노드 수, 엣지 수, 시작, 끝, 가진 돈
+	static List<Edge> edges [];
+	static boolean visit[];
+	static int ans = Integer.MAX_VALUE;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		A = Integer.parseInt(st.nextToken());
+		B = Integer.parseInt(st.nextToken());
+		C = Integer.parseInt(st.nextToken());
+		edges = new LinkedList[N+1];
+		visit = new boolean [N+1];
+		
+		for(int i=1; i<=N; i++) edges[i] = new LinkedList<>();
+		
+		for(int i=0; i<M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int start = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			int dist = Integer.parseInt(st.nextToken());
+			edges[start].add(new Edge(to, dist));
+			edges[to].add(new Edge(start, dist));
+		}
+		
+		visit[A] = true;
+		dfs(A, 0, 0);
+		
+		if(ans == Integer.MAX_VALUE) System.out.println(-1);
+		else System.out.println(ans);
+	}
+
+	static void dfs(int n, int max, int sum) {
+		if(n == B) { //목적지 도착했을 때 정답 갱신
+			ans = Integer.min(ans, max);
+			return;
+		}
+		
+		for(Edge e : edges[n]) {
+			int maxVal = Math.max(max, e.d);
+			// 이미 방문했거나, 가진 돈 초과하거나, 정답보다 큰 최대값 가지면
+			if(visit[e.to] || sum + e.d > C || maxVal > ans) continue;
+			
+			visit[e.to] = true;
+			dfs(e.to, maxVal, sum + e.d);
+			visit[e.to] = false; 
+		}
+	}
+	
+	static class Edge{
+		int to, d;
+		public Edge(int to, int d) {
+			this.to = to;
+			this.d = d;
+		}
+	}
+}

--- a/한윤석/5월 1주차/프로그래머스 연속 부분 수열 합의 개수.java
+++ b/한윤석/5월 1주차/프로그래머스 연속 부분 수열 합의 개수.java
@@ -1,0 +1,25 @@
+class Solution {
+    public int solution(int[] elements) {
+        int len = elements.length;
+        Map<Integer, Integer> dic = new HashMap<>();
+        int dp [][] = new int [len+1][len];
+        
+        // 길이 1인 부분 합 기입
+        for(int i=0; i<len; i++) {
+        	dp[1][i] = elements[i];
+        	dic.put(elements[i], 1);
+        }
+        
+        // 누적합으로 길이 2~ 의 연속 부분 수열 합 구함
+        for(int i=2; i<=len; i++) {
+        	for(int j=0; j<len; j++) {
+        		int idx = (j+i-1) % len;
+        		dp[i][j] = dp[i-1][j] + dp[1][idx];
+        		dic.put(dp[i][j], 1); // map에 계속해서 나온 수들 저장해둠
+        	}
+        }
+        
+        // map의 사이즈 = 저장된 수의 개수
+        return dic.size();
+    }
+}

--- a/한윤석/5월 1주차/프로그래머스 캐시.java
+++ b/한윤석/5월 1주차/프로그래머스 캐시.java
@@ -1,0 +1,39 @@
+public class P캐시 {
+
+	static public int solution(int cacheSize, String[] cities) {
+        int answer = 0;
+        Map<String, Integer> dic = new HashMap<>();
+        
+        for(int i=0; i<cities.length; i++) {
+        	String city = cities[i].toUpperCase();
+        	int size = dic.size();
+        	
+        	// 캐싱되어 있으면
+        	if(dic.containsKey(city)) {
+        		dic.put(city, i);
+        		answer++;
+        	}else {
+        		//이미 캐시 사이즈만큼 다 찼으면 가장 오래된 요소 제거 후 새거 넣음
+        		if(size == cacheSize) {
+        			String oldestCity = "";
+        			int oldestIdx = Integer.MAX_VALUE;
+        			
+        			for(String tempCity : dic.keySet()) {
+        				int idx = dic.get(tempCity);
+        				if(oldestIdx > idx) {
+        					oldestCity = tempCity;
+        					oldestIdx = idx;
+        				}
+        			}
+        			
+        			dic.remove(oldestCity);
+        		}
+        		if(cacheSize != 0) dic.put(city, i);
+        		answer += 5;
+        	}
+        			
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
> ### [백준] 20164 홀수 홀릭 호석
> - 난이도 : `골드5`
> - 알고리즘 유형 : `재귀`
> - 내용
> ```
> 결국 핵심은 길이가 3이상일 때, 3개의 수로 쪼개는 것인데, 이를 조합으로 풀어볼까 하다가
> 그냥 2중 포문으로도 해결이 가능해보여서 2중 포문 사용함
> 2중 포문 돌면서 문자열 자를 포인트 2군데를 도출하고, 해당 인덱스로 substring으로 문자열을 잘라서 사용
> ```

<br/>

> ### [백준] 20168 골목 대장 호석
> - 난이도 : `골드5`
> - 알고리즘 유형 : `DFS`
> - 내용
> ```
> 범위도 별로 크지 않아서 적당히 방문 처리와 정답 갱신만 해주면 되었던 문제
> DFS 돌면서 방문 처리 해주고, 목적지인 B 도착했을 때만 정답 갱신해줌
> DFS 호출 후에 visit 다시 false 해주어야 함
> ```

<br/>

> ### [프로그래머스] 캐시
> - 난이도 : `level2`
> - 알고리즘 유형 : `자료구조`
> - 내용
> ```
> 어떻게 가장 마지막에 사용한 도시를 도출할까, 캐시에 어떤 형태로 담을까가 관건이었다
> map만으로 캐시에 담긴 도시들을 저장하고, 캐싱되지 않은 도시가 이미 캐시 사이즈를 초과했을 때 들어왔을 때만 
> keyset으로 마지막 사용 인덱스 조회하고 제거해주는 방식으로 구현함
> 캐시 사이즈가 0일 때에 대한 예외처리도 필수
> ```

<br/>

> ### [프로그래머스] 연속 부분 수열 합의 개수
> - 난이도 : `level2`
> - 알고리즘 유형 : `누적합`
> - 내용
> ```
> 2차원 배열을 통해 길이가 2이상인 부분 수열부터 하나씩 누적합을 더함
> 연결되어있기 때문에 인덱싱 할 때 %연산 해주어서 누적함
> 도출된 수들을 map에 저장하고, 여기에 저장된 수들이 곧 나올 수 있는 가지수임
> ```

<br/>

> ### [출제기관] 문제번호 문제명
> - 난이도 : `난이도`
> - 알고리즘 유형 : `-`
> - 내용
> ```
> 내용작성
> ```
